### PR TITLE
Support oneliner interface for kernel targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,13 @@ fn config(args: &Args) -> Result<Vmtest> {
     }
 }
 
+/// Whether or not to collapse command output in UI.
+///
+/// This is useful for one-liner invocations.
+fn show_cmd(args: &Args) -> bool {
+    args.config.is_none()
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
@@ -63,7 +70,7 @@ fn main() -> Result<()> {
     let vmtest = config(&args)?;
     let filter = Regex::new(&args.filter).context("Failed to compile regex")?;
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&filter);
+    let failed = ui.run(&filter, show_cmd(&args));
     let rc = i32::from(failed != 0);
 
     exit(rc);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -86,7 +86,7 @@ fn assert_no_error(recv: Receiver<Output>) {
 fn test_run() {
     let vmtest = vmtest("vmtest.toml.allgood");
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&*FILTER_ALL);
+    let failed = ui.run(&*FILTER_ALL, false);
     assert_eq!(failed, 0);
 }
 


### PR DESCRIPTION
Before, you were required to create a `vmtest.toml` config file.

Now, you can run it all via command line like so:
```
$ vmtest -k ./bzImage-v6.2 "uname -r"
=> bzImage-v6.2
===> Booting
===> Setting up VM
===> Running command
6.2.0
```

With golang:
```
$ GOTMPDIR=. go test -exec "vmtest -k bzImage-v6.2 -- "
=> bzImage-v6.2
===> Booting
===> Setting up VM
===> Running command
--- FAIL: TestAdd (0.00s)
    lib_test.go:11: oops!
FAIL
Command failed with exit code: 1
exit status 1
FAIL    example.com/test        2.636s
```

With rust:
```
$ cat .cargo/config
[target.x86_64-unknown-linux-gnu]
runner = "vmtest -k bzImage-v6.2 -- "

$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests src/lib.rs (target/debug/deps/rust_vmtest-46fef259e1fcd180)
=> bzImage-v6.2
===> Booting
===> Setting up VM
===> Running command

running 1 test
test tests::it_works ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests rust-vmtest

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

This closes #3.