### PR TITLE
Retry connecting to QMP socket

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -437,9 +437,9 @@ impl Qemu {
     }
 
     /// Waits for QMP and QGA sockets to appear
-    fn wait_for_qemu(&self, timeout: Option<Duration>) -> Result<()> {
+    fn wait_for_qemu(&self) -> Result<()> {
         let now = time::Instant::now();
-        let timeout = timeout.unwrap_or(Duration::from_secs(5));
+        let timeout = Duration::from_secs(5);
 
         while now.elapsed() < timeout {
             let qga_ok = self
@@ -625,7 +625,7 @@ impl Qemu {
         // Ensure child is cleaned up even if we bail early
         let mut child = scopeguard::guard(child, Self::child_cleanup);
 
-        if let Err(e) = self.wait_for_qemu(None) {
+        if let Err(e) = self.wait_for_qemu() {
             let _ = self.updates.send(Output::BootEnd(
                 Err(e).context("Failed waiting for QEMU to be ready"),
             ));


### PR DESCRIPTION
There is most probably a race between when the sockets appear on the
filesystem and when QEMU is listening to the sockets. So we should retry
a few times in case we hit the race.