### PR TITLE
init: Ignore errors mounting debug file systems

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -43,7 +43,7 @@ umask 022
 # silent. We cannot rely on redirecting output to /dev/null yet.
 if ! mount | grep -q " /dev "; then
     log "devtmpfs not automounted, mounting at /dev"
-    mkdir /dev
+    mkdir -p /dev
     mount -t devtmpfs -o nosuid,noexec dev /dev
 fi
 
@@ -64,10 +64,10 @@ log "Mounting sysfs at /sys"
 mount -t sysfs -o nosuid,nodev,noexec sys /sys
 
 log "Mounting debugfs at /sys/kernel/debug"
-mount -t debugfs debugfs /sys/kernel/debug
+mount -t debugfs debugfs /sys/kernel/debug || log "Failed to mount debugfs. CONFIG_DEBUG_FS might be missing from the kernel config"
 
 log "Mounting tracefs at /sys/kernel/debug/tracing"
-mount -t tracefs tracefs /sys/kernel/debug/tracing
+mount -t tracefs tracefs /sys/kernel/debug/tracing || log "Failed to mount tracefs. CONFIG_DEBUG_FS might be missing from the kernel config"
 
 log "Mounting cgroup2 at /sys/fs/cgroup"
 mount -t cgroup2 -o nosuid,nodev,noexec cgroup2 /sys/fs/cgroup


### PR DESCRIPTION
Some file systems such as devtmpfs might be already mounted in the host. Some debug file systems, such debugfs and tracefs might not be present if the kernel was not built with `CONFIG_DEBUG_FS`, so let's log failures mounting them and proceed as usual.

## Before
```
Run /tmp/vmtest-initE2UZZ.sh as init process
vmtest: devtmpfs not automounted, mounting at /dev
mkdir: cannot create directory '/dev': File exists
Powering off.
ACPI: PM: Preparing to enter system sleep state S5
reboot: Power down
```

## With this patch
```
=> bzImage
===> Booting
===> Setting up VM
===> Running command
6.4.7-4e382c2b468348d6208e5a18dbf1591a18170889
```

Fixes: https://github.com/danobi/vmtest/issues/18