### PR TITLE
vmtest: Add additional config options

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         sudo apt-get update
         # Virtualization deps
-        sudo apt-get install -y qemu-system-x86-64 qemu-guest-agent ovmf
+        sudo apt-get install -y qemu-system-x86-64 qemu-guest-agent qemu-utils ovmf
 
     - name: Cache test assets
       uses: actions/cache@v3

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,3 +39,45 @@ The following fields are supported:
     * Note that the specified command is run inside a `bash` shell by default
     * `vmtest`'s environment variables are also propagated into the VM during
       command execution
+* `vm` (VMConfig)
+    * Optional sub-table
+    * Configures the VM.
+    * See the VMConfig struct below.
+
+### `[[target.vm]]`
+
+The VMConfig struct that configures the QEMU VM.
+
+* `num_cpus` (int)
+    * Optional field
+    * Number of CPUs in the VM.
+    * Default: 2
+* `memory` (string)
+    * Optional field
+    * Amount of RAM for the VM.
+    * Accepts a QEMU parsable string for the -m flag like 256M or 4G.
+    * Default: 4G
+* `mounts` (Map<String, Mount>)
+    * Optional sub-table
+    * Map of additional host mounts for the VM.
+    * Key is the path in the VM and the value contains information about the host path.
+    * See below for definition of the Mount object.
+* `bios` (string)
+    * Optional field
+    * Path to the BIOS file.
+    * This is only used if the UEFI flag from target is true.
+* `extra_args` (List<string>)
+    * Optional field
+    * Extra arguments to pass to QEMU.
+
+### `[[target.vm.mounts]]`
+
+The Mount struct for defining additional host mounts into the VM.
+
+* `host_path` (string)
+    * Required field
+    * Path on the host.
+* `writable` (bool)
+    * Optional field
+    * Whether this mount is writable in the VM.
+    * Default: false

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,79 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::vec::Vec;
 
 use serde_derive::Deserialize;
+
+/// Config for a mount
+#[derive(Deserialize, Clone)]
+pub struct Mount {
+    /// Path on the host for the mount.
+    pub host_path: PathBuf,
+    /// Mount the location r/w.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub writable: bool,
+}
+
+/// VM Config for a target
+#[derive(Deserialize)]
+pub struct VMConfig {
+    /// Number of CPUs in the VM.
+    ///
+    /// Default: 2
+    #[serde(default = "VMConfig::default_cpus")]
+    pub num_cpus: u8,
+    /// Amount of RAM for the VM.
+    ///
+    /// Accepts a QEMU parsable string for the -m flag like 256M or 4G.
+    /// Default: 4G
+    #[serde(default = "VMConfig::default_memory")]
+    pub memory: String,
+    /// Map of additional Host mounts.
+    ///
+    /// Key is the path in the VM and the value is the path on the host.
+    /// * Only respected when using an image.
+    #[serde(default = "HashMap::new")]
+    pub mounts: HashMap<String, Mount>,
+
+    /// Path to the BIOS file.
+    ///
+    /// If this is empty, the default OS locations will be tried:
+    /// * /usr/share/edk2/ovmf/OVMF_CODE.fd
+    /// * /usr/share/OVMF/OVMF_CODE.fd
+    /// * /usr/share/edk2-ovmf/x64/OVMF_CODE.fd
+    pub bios: Option<PathBuf>,
+
+    /// Extra arguments to pass to QEMU.
+    #[serde(default = "Vec::new")]
+    pub extra_args: Vec<String>,
+    // TODO: Consider adding higher level interfaces for adding
+    // additional hardware to the VM (USB, HDDs, CDROM, TPM, etc).
+    // For now, people can use extra_args to add them.
+}
+
+impl VMConfig {
+    fn default_cpus() -> u8 {
+        2
+    }
+
+    fn default_memory() -> String {
+        "4G".into()
+    }
+}
+
+impl Default for VMConfig {
+    fn default() -> Self {
+        Self {
+            num_cpus: Self::default_cpus(),
+            memory: Self::default_memory(),
+            mounts: HashMap::new(),
+            bios: None,
+            extra_args: Vec::new(),
+        }
+    }
+}
 
 /// Config for a single target
 #[derive(Deserialize)]
@@ -29,6 +101,10 @@ pub struct Target {
     pub kernel_args: Option<String>,
     /// Command to run inside virtual machine.
     pub command: String,
+
+    /// VM Configuration.
+    #[serde(default)]
+    pub vm: VMConfig,
 }
 
 /// Config containing full test matrix
@@ -73,4 +149,21 @@ fn test_triple_quoted_strings_backslash() {
         config.target[0].command,
         r#"this string has \back \slash\es"#
     );
+}
+
+#[test]
+fn test_default_vmconfig() {
+    let config: Config = toml::from_str(
+        r#"
+        [[target]]
+        name = "test"
+        command = "real command"
+        "#,
+    )
+    .unwrap();
+    assert_eq!(config.target[0].vm.memory, "4G");
+    assert_eq!(config.target[0].vm.num_cpus, 2);
+    assert_eq!(config.target[0].vm.bios, None);
+    assert_eq!(config.target[0].vm.extra_args.len(), 0);
+    assert_eq!(config.target[0].vm.mounts.len(), 0);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use console::user_attended;
 use env_logger::{fmt::Target as LogTarget, Builder};
 use regex::Regex;
 
-use ::vmtest::{Config, Target, Ui, Vmtest};
+use ::vmtest::{Config, Target, Ui, VMConfig, Vmtest};
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -75,6 +75,7 @@ fn config(args: &Args) -> Result<Vmtest> {
                 kernel: Some(kernel.clone()),
                 kernel_args: args.kargs.clone(),
                 command: args.command.join(" "),
+                vm: VMConfig::default(),
             }],
         };
 

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -103,16 +103,19 @@ fn gen_init() -> Result<NamedTempFile> {
 /// Generate arguments for inserting a file as a drive into the guest
 fn drive_args(file: &Path, index: u32) -> Vec<OsString> {
     let mut args: Vec<OsString> = Vec::new();
-
+    let disk_id = format!("disk{}", hash(file));
     args.push("-drive".into());
     args.push(
         format!(
-            "file={},index={},media=disk,if=virtio",
+            "file={},index={},media=disk,if=none,id={}",
             file.display(),
-            index
+            index,
+            disk_id
         )
         .into(),
     );
+    args.push("-device".into());
+    args.push(format!("virtio-blk-pci,drive={},bootindex={}", disk_id, index).into());
 
     args
 }
@@ -282,7 +285,7 @@ fn kernel_args(kernel: &Path, init: &Path, additional_kargs: Option<&String>) ->
     args
 }
 
-fn hash(s: &PathBuf) -> u64 {
+fn hash<T: Hash + ?Sized>(s: &T) -> u64 {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     s.hash(&mut h);
 

--- a/src/vmtest.rs
+++ b/src/vmtest.rs
@@ -42,6 +42,13 @@ fn validate_config(config: &Config) -> Result<()> {
             bail!("Target '{}' must specify 'image' with 'uefi'", target.name);
         }
 
+        if !target.uefi && target.vm.bios.is_some() {
+            bail!(
+                "Target '{}' cannot specify a bios without setting 'uefi'",
+                target.name
+            );
+        }
+
         if target.kernel_args.is_some() && target.kernel.is_none() {
             bail!(
                 "Target '{}' must specify 'kernel' with 'kernel_args'",
@@ -113,15 +120,18 @@ impl Vmtest {
             .ok_or_else(|| anyhow!("idx={} out of range", idx))?;
         let image = self.resolve_path(target.image.as_deref());
         let kernel = self.resolve_path(target.kernel.as_deref());
+        let bios = self.resolve_path(target.vm.bios.as_deref());
 
         Qemu::new(
             updates,
             image.as_deref(),
             kernel.as_deref(),
             target.kernel_args.as_ref(),
+            bios.as_deref(),
             &target.command,
             &self.base,
             target.uefi,
+            &target.vm,
         )
         .context("Failed to setup QEMU")
     }


### PR DESCRIPTION
Add a VMConfig struct to the config that will allow customizing the VM's CPUs, RAM, BIOS image, and additional host mounts. Further, allow passing in arbitrary QEMU arguments (if for example you want to add additional hardware).