### PR TITLE
test: qemu: Cleanup runtime resources

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::env;
 use std::env::consts::ARCH;
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -844,5 +845,12 @@ impl Qemu {
             // TODO(dxu): debug why we are getting errors here
             Err(e) => debug!("Failed to gracefull quit QEMU: {e}"),
         }
+    }
+}
+
+impl Drop for Qemu {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(self.qga_sock.as_path());
+        let _ = fs::remove_file(self.qmp_sock.as_path());
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -55,11 +55,14 @@ fn test_run() {
 // Expect we can run each target one by one, sucessfully
 #[test]
 fn test_run_one() {
+    let uefi_image = create_new_image(asset("image-uefi.raw-efi"));
+    let non_uefi_image = create_new_image(asset("image-not-uefi.raw"));
+
     let config = Config {
         target: vec![
             Target {
                 name: "uefi image boots with uefi flag".to_string(),
-                image: create_new_image(asset("image-uefi.raw-efi")),
+                image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
@@ -68,7 +71,7 @@ fn test_run_one() {
             },
             Target {
                 name: "not uefi image boots without uefi flag".to_string(),
-                image: create_new_image(asset("image-not-uefi.raw")),
+                image: Some(non_uefi_image.as_pathbuf()),
                 uefi: false,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
@@ -88,11 +91,14 @@ fn test_run_one() {
 // Expect that we have bounds checks
 #[test]
 fn test_run_out_of_bounds() {
+    let uefi_image = create_new_image(asset("image-uefi.raw-efi"));
+    let non_uefi_image = create_new_image(asset("image-not-uefi.raw"));
+
     let config = Config {
         target: vec![
             Target {
                 name: "uefi image boots with uefi flag".to_string(),
-                image: create_new_image(asset("image-uefi.raw-efi")),
+                image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
@@ -101,7 +107,7 @@ fn test_run_out_of_bounds() {
             },
             Target {
                 name: "not uefi image boots without uefi flag".to_string(),
-                image: create_new_image(asset("image-not-uefi.raw")),
+                image: Some(non_uefi_image.as_pathbuf()),
                 uefi: false,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
@@ -119,10 +125,12 @@ fn test_run_out_of_bounds() {
 // Try running a uefi image without uefi flag. It should fail to boot.
 #[test]
 fn test_not_uefi() {
+    let uefi_image = create_new_image(asset("image-uefi.raw-efi"));
+
     let config = Config {
         target: vec![Target {
             name: "uefi image does not boot without uefi flag".to_string(),
-            image: create_new_image(asset("image-uefi.raw-efi")),
+            image: Some(uefi_image.as_pathbuf()),
             uefi: false,
             command: "echo unreachable".to_string(),
             kernel: None,
@@ -270,11 +278,13 @@ fn test_kernel_ro_flag() {
 
 #[test]
 fn test_run_custom_resources() {
+    let uefi_image = create_new_image(asset("image-uefi.raw-efi"));
+
     let config = Config {
         target: vec![
             Target {
                 name: "Custom number of CPUs".to_string(),
-                image: create_new_image(asset("image-uefi.raw-efi")),
+                image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "[[ "$(nproc)" == "1" ]]""#.into(),
                 kernel: None,
@@ -286,7 +296,7 @@ fn test_run_custom_resources() {
             },
             Target {
                 name: "Custom amount of RAM".to_string(),
-                image: create_new_image(asset("image-uefi.raw-efi")),
+                image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 // Should be in the 200 thousands, but it's variable.
                 command: r#"bash -xc "cat /proc/meminfo | grep 'MemTotal:         2..... kB'""#
@@ -310,11 +320,13 @@ fn test_run_custom_resources() {
 
 #[test]
 fn test_run_custom_mounts() {
+    let uefi_image = create_new_image(asset("image-uefi.raw-efi"));
+
     let config = Config {
         target: vec![
             Target {
                 name: "mount".to_string(),
-                image: create_new_image(asset("image-uefi.raw-efi")),
+                image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "[[ -e /tmp/mount/README.md ]]""#.into(),
                 kernel: None,
@@ -332,7 +344,7 @@ fn test_run_custom_mounts() {
             },
             Target {
                 name: "RO mount".to_string(),
-                image: create_new_image(asset("image-uefi.raw-efi")),
+                image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "(touch /tmp/ro/hi && exit -1) || true""#.into(),
                 kernel: None,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,13 +2,9 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::Path;
-use std::path::PathBuf;
-use std::process::Command;
 use std::sync::mpsc::channel;
 
 use lazy_static::lazy_static;
-use log::error;
-use rand::Rng;
 use regex::Regex;
 use tempfile::tempdir_in;
 use test_log::test;
@@ -23,43 +19,6 @@ use helpers::*;
 
 lazy_static! {
     static ref FILTER_ALL: Regex = Regex::new(".*").unwrap();
-}
-
-fn gen_image_name() -> PathBuf {
-    let mut path = PathBuf::new();
-    path.push("/tmp");
-
-    let id = rand::thread_rng().gen_range(100_000..1_000_000);
-    let image = format!("/tmp/image-{id}.qcow2");
-    path.push(image);
-
-    path
-}
-
-// Create a CoW image to ensure each test runs in a clean image.
-fn create_new_image(image: PathBuf) -> Option<PathBuf> {
-    let out_image = gen_image_name();
-    let out = Command::new("qemu-img")
-        .arg("create")
-        .arg("-F")
-        .arg("raw")
-        .arg("-b")
-        .arg(image)
-        .arg("-f")
-        .arg("qcow2")
-        .arg(out_image.clone())
-        .output()
-        .expect("error creating image file");
-    if !out.status.success() {
-        error!(
-            "error creating image file: out={} err={} status={}",
-            std::str::from_utf8(&out.stdout).unwrap(),
-            std::str::from_utf8(&out.stderr).unwrap(),
-            out.status
-        );
-        return None;
-    }
-    Some(out_image)
 }
 
 // Expect that we can run the entire matrix successfully


### PR DESCRIPTION
Best not to leave resources generated at runtime laying around after we're done using them.

This closes #25.