### PR TITLE
qga: Retry the connection every second.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all:
 
 .PHONY: test
 test: $(IMAGES_FILES) $(KERNELS_FILES)
-	@RUST_LOG=debug cargo test -- --test-threads=1
+	@RUST_LOG=debug cargo test -- --test-threads=1 --nocapture
 
 .PHONY: clean
 clean:

--- a/src/qga.rs
+++ b/src/qga.rs
@@ -1,16 +1,14 @@
-
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 
-
-
+use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Context, Result};
-use log::{error, warn};
+use anyhow::{bail, Context, Result};
+use log::{error, info, warn};
 use qapi::{qga, Command as QapiCommand, Qga};
 use rand::Rng;
-use scopeguard::defer;
+
 
 const KVM_TIMEOUT: Duration = Duration::from_secs(30);
 const EMULATE_TIMEOUT: Duration = Duration::from_secs(120);
@@ -41,23 +39,33 @@ impl QgaWrapper {
         // If we try reading the socket too  early, we'll hang forever and never run the test.
         // So do the guest_sync first with a timeout to ensure that the VM Guest Agent is up.
         let end = Instant::now() + timeout;
+        let mut i = 0;
         while Instant::now() < end {
+            info!("Connecting to QGA ({i})");
+            i += 1;
             let qga_stream = match UnixStream::connect(&sock) {
                 Ok(s) => s,
                 Err(e) => {
                     error!("Failed to connect QGA, retrying: {}", e);
+                    thread::sleep(Duration::from_secs(1));
                     continue;
                 }
             };
-            qga_stream.set_read_timeout(Some(Duration::from_secs(1)))?;
+            qga_stream.set_read_timeout(Some(Duration::from_secs(5)))?;
             let mut qga = Qga::from_stream(&qga_stream);
             let sync_value = rand::thread_rng().gen_range(1..10_000);
-            if let Ok(_) = qga.guest_sync(sync_value) {
-                return Ok(Self { stream: qga_stream });
+            match qga.guest_sync(sync_value) {
+                Ok(_) => {
+                    return Ok(Self { stream: qga_stream });
+                }
+                Err(e) => {
+                    warn!("QGA sync failed, retrying: {e}");
+                    thread::sleep(Duration::from_secs(1));
+                }
             }
         }
 
-        Err(anyhow!("Timed out waiting for QGA connection"))
+        bail!("Timed out waiting for QGA connection");
     }
 
     /// Run a command inside the guest
@@ -65,9 +73,6 @@ impl QgaWrapper {
         &self,
         args: qga::guest_exec,
     ) -> Result<<qga::guest_exec as QapiCommand>::Ok> {
-        if let Err(e) = self.stream.set_read_timeout(None) {
-            warn!("Error setting socket timeout: {e}");
-        }
         let mut qga = Qga::from_stream(&self.stream);
         qga.execute(&args).context("Error running guest_exec")
     }
@@ -77,14 +82,6 @@ impl QgaWrapper {
         &self,
         pid: i64,
     ) -> Result<<qga::guest_exec_status as QapiCommand>::Ok> {
-        defer! {
-            if let Err(e) = self.stream.set_read_timeout(None) {
-                warn!("Error setting socket timeout: {e}");
-            }
-        };
-        if let Err(e) = self.stream.set_read_timeout(Some(Duration::from_secs(5))) {
-            warn!("Error setting socket timeout: {e}");
-        }
         let mut qga = Qga::from_stream(&self.stream);
         qga.execute(&qga::guest_exec_status { pid })
             .context("error running guest_exec_status")

--- a/src/qga.rs
+++ b/src/qga.rs
@@ -1,14 +1,16 @@
+
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
-use std::sync::mpsc;
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
-use std::thread;
+
+
+
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, bail, Result};
-use log::{debug, error};
+use anyhow::{anyhow, Context, Result};
+use log::{error, warn};
 use qapi::{qga, Command as QapiCommand, Qga};
 use rand::Rng;
+use scopeguard::defer;
 
 const KVM_TIMEOUT: Duration = Duration::from_secs(30);
 const EMULATE_TIMEOUT: Duration = Duration::from_secs(120);
@@ -21,22 +23,7 @@ const EMULATE_TIMEOUT: Duration = Duration::from_secs(120);
 /// to execute all commands with a timeout so we can provide a user friendly
 /// error message if QGA never comes up in the guest.
 pub struct QgaWrapper {
-    send_req: Sender<QgaWrapperCommand>,
-    recv_resp: Receiver<Result<QgaWrapperCommandResp>>,
-}
-
-#[allow(clippy::enum_variant_names)]
-pub enum QgaWrapperCommand {
-    GuestSync,
-    GuestExec(qga::guest_exec),
-    GuestExecStatus(qga::guest_exec_status),
-}
-
-#[allow(clippy::enum_variant_names)]
-pub enum QgaWrapperCommandResp {
-    GuestSync,
-    GuestExec(<qga::guest_exec as QapiCommand>::Ok),
-    GuestExecStatus(<qga::guest_exec_status as QapiCommand>::Ok),
+    stream: UnixStream,
 }
 
 impl QgaWrapper {
@@ -64,94 +51,13 @@ impl QgaWrapper {
             };
             qga_stream.set_read_timeout(Some(Duration::from_secs(1)))?;
             let mut qga = Qga::from_stream(&qga_stream);
-            let sync_value = &qga_stream as *const _ as usize as i32;
+            let sync_value = rand::thread_rng().gen_range(1..10_000);
             if let Ok(_) = qga.guest_sync(sync_value) {
-                break;
+                return Ok(Self { stream: qga_stream });
             }
         }
-        let (send_req, recv_req) = mpsc::channel();
-        let (send_resp, recv_resp) = mpsc::channel();
 
-        // Start worker thread to service requests
-        thread::spawn(move || Self::worker(sock, recv_req, send_resp));
-
-        let r = Self {
-            send_req,
-            recv_resp,
-        };
-
-        r.guest_sync(timeout)?;
-
-        Ok(r)
-    }
-
-    /// Worker thread that fields QGA requests from the main thread
-    fn worker(
-        sock: PathBuf,
-        recv_req: Receiver<QgaWrapperCommand>,
-        send_resp: Sender<Result<QgaWrapperCommandResp>>,
-    ) {
-        let qga_stream = match UnixStream::connect(sock) {
-            Ok(s) => s,
-            Err(e) => {
-                // If we fail to connect to socket, exit this thread. The main
-                // thread will detect a hangup and error accordingly.
-                error!("Failed to connect QGA: {}", e);
-                return;
-            }
-        };
-        let mut qga = Qga::from_stream(&qga_stream);
-
-        // We only get an error if other end hangs up. In the event of a hang up,
-        // we gracefully terminate.
-        while let Ok(req) = recv_req.recv() {
-            let resp = match req {
-                QgaWrapperCommand::GuestSync => {
-                    let sync_value = rand::thread_rng().gen_range(1..10_000);
-                    match qga.guest_sync(sync_value) {
-                        Ok(_) => Ok(QgaWrapperCommandResp::GuestSync),
-                        Err(e) => Err(anyhow!("Failed to guest_sync: {}", e)),
-                    }
-                }
-                QgaWrapperCommand::GuestExec(args) => match qga.execute(&args) {
-                    Ok(r) => Ok(QgaWrapperCommandResp::GuestExec(r)),
-                    Err(e) => Err(anyhow!("Failed to guest_exec: {}", e)),
-                },
-                QgaWrapperCommand::GuestExecStatus(args) => match qga.execute(&args) {
-                    Ok(r) => Ok(QgaWrapperCommandResp::GuestExecStatus(r)),
-                    Err(e) => Err(anyhow!("Failed to guest_exec_status: {}", e)),
-                },
-            };
-
-            // Note we do not care if this succeeds or not.
-            // It is OK if receiver has gone away (eg we got timed out).
-            let _ = send_resp.send(resp);
-        }
-    }
-
-    /// Ask the worker thread to complete a request
-    fn execute(&self, cmd: QgaWrapperCommand, timeout: Duration) -> Result<QgaWrapperCommandResp> {
-        match self.send_req.send(cmd) {
-            Ok(_) => (),
-            Err(e) => {
-                debug!("Failed to send QGA command: {}", e);
-                bail!("Failed to send QGA command: worker thread is dead")
-            }
-        };
-
-        match self.recv_resp.recv_timeout(timeout) {
-            Ok(r) => r,
-            Err(RecvTimeoutError::Timeout) => bail!("Timed out waiting for QGA"),
-            Err(RecvTimeoutError::Disconnected) => {
-                bail!("Failed to recv QGA command: worker thread is dead")
-            }
-        }
-    }
-
-    /// Sync with qemu-ga inside guest
-    pub fn guest_sync(&self, timeout: Duration) -> Result<()> {
-        self.execute(QgaWrapperCommand::GuestSync, timeout)
-            .map(|_| ())
+        Err(anyhow!("Timed out waiting for QGA connection"))
     }
 
     /// Run a command inside the guest
@@ -159,10 +65,11 @@ impl QgaWrapper {
         &self,
         args: qga::guest_exec,
     ) -> Result<<qga::guest_exec as QapiCommand>::Ok> {
-        match self.execute(QgaWrapperCommand::GuestExec(args), Duration::MAX)? {
-            QgaWrapperCommandResp::GuestExec(resp) => Ok(resp),
-            _ => panic!("Impossible return"),
+        if let Err(e) = self.stream.set_read_timeout(None) {
+            warn!("Error setting socket timeout: {e}");
         }
+        let mut qga = Qga::from_stream(&self.stream);
+        qga.execute(&args).context("Error running guest_exec")
     }
 
     /// Query status of a command inside the guest
@@ -170,12 +77,16 @@ impl QgaWrapper {
         &self,
         pid: i64,
     ) -> Result<<qga::guest_exec_status as QapiCommand>::Ok> {
-        match self.execute(
-            QgaWrapperCommand::GuestExecStatus(qga::guest_exec_status { pid }),
-            Duration::from_secs(5),
-        )? {
-            QgaWrapperCommandResp::GuestExecStatus(resp) => Ok(resp),
-            _ => panic!("Impossible return"),
+        defer! {
+            if let Err(e) = self.stream.set_read_timeout(None) {
+                warn!("Error setting socket timeout: {e}");
+            }
+        };
+        if let Err(e) = self.stream.set_read_timeout(Some(Duration::from_secs(5))) {
+            warn!("Error setting socket timeout: {e}");
         }
+        let mut qga = Qga::from_stream(&self.stream);
+        qga.execute(&qga::guest_exec_status { pid })
+            .context("error running guest_exec_status")
     }
 }


### PR DESCRIPTION
If we connect to the QGA socket too early, the VM's QGA will never respond to us no matter how many times we write commands to it.

So, do the guest_sync first synchronously and recreate the socket each attempt until it passes. Then hand off to the thread loop.

Fixes #17 