### PR TITLE
qga: Fix command waiting logic

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -410,11 +410,6 @@ where
             break status.exitcode.unwrap_or(0);
         }
 
-        // Exponential backoff up to 5s so we don't poll too frequently
-        if period <= (Duration::from_secs(5) / 2) {
-            period *= 2;
-        }
-
         let elapsed = now.elapsed();
         if now.elapsed() >= Duration::from_secs(30) {
             warn!(
@@ -423,8 +418,13 @@ where
             );
         }
 
-        debug!("PID={pid} not finished; sleeping {}s", period.as_millis());
+        debug!("PID={pid} not finished; sleeping {} ms", period.as_millis());
         thread::sleep(period);
+
+        // Exponential backoff up to 5s so we don't poll too frequently
+        if period <= (Duration::from_secs(5) / 2) {
+            period *= 2;
+        }
     };
 
     Ok(rc)

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -159,6 +159,9 @@ impl Drop for CowImage {
 }
 
 // Create a CoW image to ensure each test runs in a clean image.
+//
+// We've seen some really odd flakiness issues when the same image
+// is reused. It may be a nixos thing. Still unclear.
 pub fn create_new_image(image: PathBuf) -> CowImage {
     let out_image = gen_image_name();
     let out = Command::new("qemu-img")

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -278,13 +278,14 @@ fn test_kernel_ro_flag() {
 
 #[test]
 fn test_run_custom_resources() {
-    let uefi_image = create_new_image(asset("image-uefi.raw-efi"));
+    let uefi_image_t1 = create_new_image(asset("image-uefi.raw-efi"));
+    let uefi_image_t2 = create_new_image(asset("image-uefi.raw-efi"));
 
     let config = Config {
         target: vec![
             Target {
                 name: "Custom number of CPUs".to_string(),
-                image: Some(uefi_image.as_pathbuf()),
+                image: Some(uefi_image_t1.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "[[ "$(nproc)" == "1" ]]""#.into(),
                 kernel: None,
@@ -296,7 +297,7 @@ fn test_run_custom_resources() {
             },
             Target {
                 name: "Custom amount of RAM".to_string(),
-                image: Some(uefi_image.as_pathbuf()),
+                image: Some(uefi_image_t2.as_pathbuf()),
                 uefi: true,
                 // Should be in the 200 thousands, but it's variable.
                 command: r#"bash -xc "cat /proc/meminfo | grep 'MemTotal:         2..... kB'""#


### PR DESCRIPTION
Initial wait period was intended to be 200ms. But we were backing off before sleeping so it was in reality 400ms. Fix by moving backoff until after sleep.

Also fix typo (s -> ms).