### PR TITLE
init: symlink /dev/fd to /proc/self/fd

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -75,6 +75,10 @@ mount -t cgroup2 -o nosuid,nodev,noexec cgroup2 /sys/fs/cgroup
 log "Mounting tmpfs at /mnt"
 mount -t tmpfs -o nosuid,nodev tmpfs /mnt
 
+# Symlink /dev/fd to /proc/self/fd so process substitution works.
+log "Symlink /dev/fd to /proc/self/fd"
+[[ -a /dev/fd ]] || ln -s /proc/self/fd /dev/fd
+
 log "Init done"
 
 # Locate our QGA virtio port


### PR DESCRIPTION
For process substitution to work, /dev/fd needs to be symlinked to /proc/self/fd

Without the change, the newly added `test_command_process_substitution` test would fail with:
```
---- test_command_process_substitution stdout ----
Command output=bash: line 1: cd: /tmp/.tmpr2SM0u: No such file or directory
Command output=cat: /dev/fd/63: No such file or directory
[tests/test.rs:251] get_error(recv, None) = Some(
    "Command failed with 1",
)
thread 'test_command_process_substitution' panicked at 'assertion failed: dbg!(get_error(recv, None)).is_none()', tests/test.rs:251:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    test_command_process_substitution

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 11 filtered out; finished in 2.41s

error: test failed, to rerun pass `--test test`
```

After the change, the test pass and it is possible to run:
```
$ cargo run --  -k $KERNEL_REPO/arch/x86_64/boot/bzImage "tail <(cat README.md)
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/vmtest -k /home/chantra/devel/bpf-next//arch/x86_64/boot/bzImage 'tail <(cat README.md)'`
=> bzImage
===> Booting
===> Setting up VM
===> Running command

For general architecture notes, see [architecture.md](./docs/architecture.md).

Many thanks to [`drgn`'s
vmtest](https://github.com/osandov/drgn/tree/main/vmtest) by Omar Sandoval and
Andy Lutomirski's most excellent [`virtme`](https://github.com/amluto/virtme)
for providing both ideas and technical exploration.
```