### PR TITLE
run kernel in chroot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +218,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
+name = "futures"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+
+[[package]]
+name = "futures-task"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +322,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "heck"
@@ -301,6 +408,18 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -461,6 +580,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "relative-path"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.29",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +647,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
@@ -514,6 +683,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -618,6 +796,7 @@ dependencies = [
  "qapi",
  "rand",
  "regex",
+ "rstest",
  "scopeguard",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.70.0"
 
 [dependencies]
 anyhow = "1.0.66"
-clap = { version = "4.0.26", features = ["derive"] }
+clap = { version = "4.0.26", features = ["derive", "string"] }
 console = "0.15.5"
 env_logger = "0.10.0"
 itertools = "0.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ toml = "0.5.9"
 
 [dev-dependencies]
 test-log = "0.2.11"
+rstest = "0.18.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,12 +99,26 @@ pub struct Target {
     ///
     /// Arguments are only valid for kernel targets.
     pub kernel_args: Option<String>,
+    /// Path to rootfs to test against.
+    ///
+    /// * The path is relative to `vmtest.toml`.
+    /// * If not specified, the host's rootfs will be used.
+    /// Default: /
+    #[serde(default = "Target::default_rootfs")]
+    pub rootfs: PathBuf,
     /// Command to run inside virtual machine.
     pub command: String,
 
     /// VM Configuration.
     #[serde(default)]
     pub vm: VMConfig,
+}
+
+impl Target {
+    /// Default rootfs path to use if none are specified.
+    pub fn default_rootfs() -> PathBuf {
+        "/".into()
+    }
 }
 
 /// Config containing full test matrix

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use console::user_attended;
 use env_logger::{fmt::Target as LogTarget, Builder};
 use regex::Regex;
 
-use ::vmtest::{Config, Target, Ui, VMConfig, Vmtest};
+use vmtest::{Config, Target, Ui, VMConfig, Vmtest};
 
 #[derive(Parser, Debug)]
 #[clap(version)]
@@ -31,6 +31,9 @@ struct Args {
     /// Additional kernel command line arguments
     #[clap(long, conflicts_with = "config")]
     kargs: Option<String>,
+    /// Location of rootfs, default to host's /
+    #[clap(short, long, conflicts_with = "config", default_value = Target::default_rootfs().into_os_string())]
+    rootfs: PathBuf,
     #[clap(conflicts_with = "config")]
     command: Vec<String>,
 }
@@ -73,6 +76,7 @@ fn config(args: &Args) -> Result<Vmtest> {
                 image: None,
                 uefi: false,
                 kernel: Some(kernel.clone()),
+                rootfs: args.rootfs.clone(),
                 kernel_args: args.kargs.clone(),
                 command: args.command.join(" "),
                 vm: VMConfig::default(),

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -76,6 +76,15 @@ fn gen_sock(prefix: &str) -> PathBuf {
     path
 }
 
+// Given a guest temp dir and a host init path, generate the path to the init file
+// in the guest.
+// This path is the one that will be passed to the guest via the kernel's `init=` parameter.
+fn guest_init_path(guest_temp_dir: PathBuf, host_init_path: PathBuf) -> PathBuf {
+    let mut guest_init_path = guest_temp_dir;
+    guest_init_path.push(host_init_path.file_name().unwrap());
+    guest_init_path
+}
+
 // Given a rootfs, generate a tempfile with the init script inside.
 // Returns the tempfile and the path to the init script inside the guest.
 // When rootfs is /, both the tempfile filename and guest init path are equal.
@@ -111,7 +120,7 @@ fn gen_init(rootfs: &Path) -> Result<(NamedTempFile, PathBuf)> {
 
     // Path in the guest is our guest_temp_dir to which we append the file
     // name of the host init script.
-    let guest_init = guest_temp_dir.join(host_init.path().file_name().unwrap());
+    let guest_init = guest_init_path(guest_temp_dir, host_init.path().to_path_buf());
     debug!(
         "rootfs path: {rootfs:?}, init host path: {host_init:?}, init guest path: {guest_init:?}"
     );
@@ -897,5 +906,36 @@ impl Drop for Qemu {
     fn drop(&mut self) {
         let _ = fs::remove_file(self.qga_sock.as_path());
         let _ = fs::remove_file(self.qmp_sock.as_path());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::guest_init_path;
+    use rstest::rstest;
+
+    use std::path::PathBuf;
+
+    #[rstest]
+    // no trailing /
+    #[case("/tmp", "/foo/tmp/bar.sh", "/tmp/bar.sh")]
+    // with trailing /
+    #[case("/tmp/", "/foo/tmp/bar.sh", "/tmp/bar.sh")]
+    // A valid case if rootfs was /foo/tmp and env::temp_dir() was /.
+    #[case("/", "/foo/tmp/bar.sh", "/bar.sh")]
+    // This should never happen given that host_init_path is made by appending guest_temp_dir to rootfs.
+    // for now it will return a guest_init_path which won't work.
+    #[case("/tmp", "/foo/bar.sh", "/tmp/bar.sh")]
+    // A valid case if env::temp_dir() was /foo/tmp and rootfs was /.
+    #[case("/foo/tmp", "/foo/tmp/bar.sh", "/foo/tmp/bar.sh")]
+    // Invalid case because guest_temp_dir is not a suffix of dirname(host_init_path)
+    #[case("/foo/tmp", "/bar/tmp/bar.sh", "/foo/tmp/bar.sh")]
+    fn test_guest_init_path(
+        #[case] guest_temp_dir: &str,
+        #[case] host_init_path: &str,
+        #[case] expected: &str,
+    ) {
+        let r = guest_init_path(guest_temp_dir.into(), host_init_path.into());
+        assert_eq!(r, PathBuf::from(expected));
     }
 }

--- a/src/vmtest.rs
+++ b/src/vmtest.rs
@@ -120,6 +120,7 @@ impl Vmtest {
             .ok_or_else(|| anyhow!("idx={} out of range", idx))?;
         let image = self.resolve_path(target.image.as_deref());
         let kernel = self.resolve_path(target.kernel.as_deref());
+        let rootfs = self.resolve_path(Some(target.rootfs.as_path())).unwrap();
         let bios = self.resolve_path(target.vm.bios.as_deref());
 
         Qemu::new(
@@ -127,6 +128,7 @@ impl Vmtest {
             image.as_deref(),
             kernel.as_deref(),
             target.kernel_args.as_ref(),
+            rootfs.as_path(),
             bios.as_deref(),
             &target.command,
             &self.base,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,6 +33,7 @@ fn test_run() {
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig::default(),
             },
             Target {
@@ -42,6 +43,7 @@ fn test_run() {
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig::default(),
             },
         ],
@@ -67,6 +69,7 @@ fn test_run_one() {
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig::default(),
             },
             Target {
@@ -76,6 +79,7 @@ fn test_run_one() {
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig::default(),
             },
         ],
@@ -103,6 +107,7 @@ fn test_run_out_of_bounds() {
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig::default(),
             },
             Target {
@@ -112,6 +117,7 @@ fn test_run_out_of_bounds() {
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig::default(),
             },
         ],
@@ -135,6 +141,7 @@ fn test_not_uefi() {
             command: "echo unreachable".to_string(),
             kernel: None,
             kernel_args: None,
+            rootfs: Target::default_rootfs(),
             vm: VMConfig::default(),
         }],
     };
@@ -151,6 +158,7 @@ fn test_command_runs_in_shell() {
             name: "command is run in shell".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
             kernel_args: None,
+            rootfs: Target::default_rootfs(),
             // `$0` is a portable way of getting the name of the shell without relying
             // on env vars which may be propagated from the host into the guest.
             command: "if true; then echo -n $0 > /mnt/vmtest/result; fi".to_string(),
@@ -179,6 +187,7 @@ fn test_kernel_target_env_var_propagation() {
             name: "host env vars are propagated into guest".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
             kernel_args: None,
+            rootfs: Target::default_rootfs(),
             command: "echo -n $TEST_ENV_VAR > /mnt/vmtest/result".to_string(),
             image: None,
             uefi: false,
@@ -208,6 +217,7 @@ fn test_kernel_target_cwd_preserved() {
             name: "host cwd preserved in guest".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
             kernel_args: None,
+            rootfs: Target::default_rootfs(),
             command: "cat text_file.txt".to_string(),
             image: None,
             uefi: false,
@@ -237,6 +247,7 @@ fn test_command_process_substitution() {
             name: "command can run process substitution".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
             kernel_args: None,
+            rootfs: Target::default_rootfs(),
             // `$0` is a portable way of getting the name of the shell without relying
             // on env vars which may be propagated from the host into the guest.
             command: "cat <(echo -n $0) > /mnt/vmtest/result".to_string(),
@@ -263,6 +274,7 @@ fn test_qemu_error_shown() {
             name: "invalid kernel path".to_string(),
             kernel: Some(asset("doesn't exist")),
             kernel_args: None,
+            rootfs: Target::default_rootfs(),
             command: "true".to_string(),
             image: None,
             uefi: false,
@@ -290,6 +302,7 @@ fn test_kernel_ro_flag() {
             name: "cannot touch host rootfs with ro".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
             kernel_args: Some("ro".to_string()),
+            rootfs: Target::default_rootfs(),
             command: format!("touch {}/file", touch_dir.path().display()),
             image: None,
             uefi: false,
@@ -316,6 +329,7 @@ fn test_run_custom_resources() {
                 command: r#"bash -xc "[[ "$(nproc)" == "1" ]]""#.into(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     num_cpus: 1,
                     ..Default::default()
@@ -330,6 +344,7 @@ fn test_run_custom_resources() {
                     .into(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     memory: "256M".into(),
                     ..Default::default()
@@ -358,6 +373,7 @@ fn test_run_custom_mounts() {
                 command: r#"bash -xc "[[ -e /tmp/mount/README.md ]]""#.into(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     mounts: HashMap::from([(
                         "/tmp/mount".into(),
@@ -376,6 +392,7 @@ fn test_run_custom_mounts() {
                 command: r#"bash -xc "(touch /tmp/ro/hi && exit -1) || true""#.into(),
                 kernel: None,
                 kernel_args: None,
+                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     mounts: HashMap::from([(
                         "/tmp/ro".into(),


### PR DESCRIPTION
Insteads of mounting the local FS'root, we can do the same but in a chroot. The main benefit would be to be able to run a kernel/artifacts in a guest FS which may be different then the host FS. For instance when collecting CI artifacts and trying to reproduce locally.
CI may run in say Ubuntu 22.04 , while my host may be Fedora 38. This also opens up for a next diff where we can run againdt a foreign architecture provided that the chrrot is for that arch.
```
$ cat /etc/debian_version && RUST_LOG=debug cargo run -- -k $KERNEL_REPO/arch/x86_64/boot/bzImage -r debian 'cat /etc/debian_version'
trixie/sid
   Compiling vmtest v0.8.3 (/home/chantra/devel/danobi-vmtest)
    Finished dev [unoptimized + debuginfo] target(s) in 8.11s
     Running `target/debug/vmtest -k /home/chantra/devel/bpf-next//arch/x86_64/boot/bzImage -r debian 'cat /etc/debian_version'`
=> bzImage
===> Booting
===> Setting up VM
===> Running command
11.5
bash: line 1: cd: /home/chantra/devel/danobi-vmtest: No such file or directory
```

Also tested that it would work when configured in `vmtest.toml`

```
$ RUST_LOG=debug cargo run --
   Compiling vmtest v0.8.3 (/home/chantra/devel/danobi-vmtest)
    Finished dev [unoptimized + debuginfo] target(s) in 2.50s
     Running `target/debug/vmtest`
=> Alt RootFS
===> Booting
===> Setting up VM
===> Running command
11.5
bash: line 1: cd: /home/chantra: No such file or directory
=> Standard RootFS
===> Booting
===> Setting up VM
===> Running command
trixie/sid
$ cat vmtest.toml
[[target]]
name = "Alt RootFS"
kernel = "/home/chantra/devel/bpf-next//arch/x86_64/boot/bzImage"
command = "cat /etc/debian_version"
rootfs = "debian"

[[target]]
name = "Standard RootFS"
kernel = "/home/chantra/devel/bpf-next//arch/x86_64/boot/bzImage"
command = "cat /etc/debian_version"
```