### PR TITLE
Refactor args

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ pub struct Mount {
 }
 
 /// VM Config for a target
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct VMConfig {
     /// Number of CPUs in the VM.
     ///
@@ -76,7 +76,7 @@ impl Default for VMConfig {
 }
 
 /// Config for a single target
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct Target {
     /// Name of the testing target.
     pub name: String,


### PR DESCRIPTION
Qemu::new is getting unwieldy with a lot of parameters... even clippy is unhappy about it:
```
warning: this function has too many arguments (10/7)
```

Most of those parameters are essentially forwarding content from the Target/VM config.

It is easier to just pass the whole Target content so it can be passed around as needed without adding more parameters down the stack.