### PR TITLE
ci: Set kvm perms

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,14 @@ jobs:
         path: tests/.assets
         key: ${{ hashFiles('Makefile') }}-${{ hashFiles('tests/images/*') }}-${{ hashFiles('tests/kernels/*') }}-assets
 
+    - name: Enable KVM group perms
+      run: |
+        # Only configure kvm perms if kvm is available
+        [[ -f /dev/kvm ]] || exit 0
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
     - name: Run integration tests
       run: make test
 


### PR DESCRIPTION
Been getting a lot of the following error in CI runs lately:

    [tests/test.rs:91] get_error(recv, None) = Some(
        Error {
            context: "Could not access KVM kernel module: Permission denied\nqemu-system-x86_64: failed to initialize kvm: Permission denied\n",
            source: Error {
                context: "Failed to connect QMP",
                source: Os {
                    code: 111,
                    kind: ConnectionRefused,
                    message: "Connection refused",
                },
            },
        },
    )

It happens on and off for no good reason. No idea why. I'm guessing GHA might be slowly rolling out nested virt to non-large runners?

The fix in this commit is required for large runners to use nested virt. Maybe we need this for regular runners now.

See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/