### PR TITLE
Send qemu-ga logs out via /dev/kmsg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,10 +47,12 @@ jobs:
     - name: Enable KVM group perms
       run: |
         # Only configure kvm perms if kvm is available
-        [[ -f /dev/kvm ]] || exit 0
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
+        if [[ -e /dev/kvm ]]; then
+          echo "Updating KVM permissions"
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+        fi
 
     - name: Run integration tests
       run: make test

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -95,5 +95,11 @@ if [[ -z "$vport" ]]; then
 fi
 log "Located qemu-guest-agent virtio port: ${vport}"
 
+# Send QGA logs out via kmsg if possible
+qga_logs=
+if [[ -e /dev/kmsg ]]; then
+    qga_logs="--logfile /dev/kmsg"
+fi
+
 log "Spawning qemu-ga"
-qemu-ga --method=virtio-serial --path="$vport"
+qemu-ga --method=virtio-serial --path="$vport" $qga_logs


### PR DESCRIPTION
`/dev/kmsg` is conveniently hooked up to the host, where vmtest is listening. Rather than create yet another side channel, reuse a reliable existing one.