### PR TITLE
Stream main command output to screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +773,7 @@ dependencies = [
  "serde_derive",
  "tempfile",
  "test-log",
+ "tinytemplate",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ scopeguard = "1.1.0"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 tempfile = "3.5.0"
+tinytemplate = "1.2.1"
 toml = "0.5.9"
 
 [dev-dependencies]

--- a/src/init/command.template
+++ b/src/init/command.template
@@ -6,5 +6,26 @@
 cd { host_shared }
 {{ endif }}
 
+# Discover where the output chardev is located
+vport=
+for dir in /sys/class/virtio-ports/*; do
+    if [[ "$(cat "$dir/name")" == "{ command_output_port_name }" ]]; then
+        vport_name=$(basename "$dir")
+        vport="/dev/$vport_name"
+    fi
+done
+
+# Send the rest of the script to the output chardev
+if [[ -n "$vport" ]]; then
+    exec > "$vport"
+    exec 2>&1
+else
+    # Make a missing serial port a soft error. We don't necessarily need
+    # streamed command output -- it's completely a UX thing. It's more
+    # likely this fails on images.
+    echo >&2 "vmtest: Failed to locate command output virtio-serial port."
+    echo >&2 "vmtest: Falling back to qemu-guest-agent output capture."
+fi
+
 # Run user supplied command
 { command }

--- a/src/init/command.template
+++ b/src/init/command.template
@@ -1,0 +1,10 @@
+# This is the entrypoint for vmtest commands in both kernel and image targets.
+# We use a small rendering engine so it's easier to read/write more complex logic.
+
+# Propagate current working directory on host into guest if requested
+{{ if should_cd }}
+cd { host_shared }
+{{ endif }}
+
+# Run user supplied command
+{ command }

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -75,6 +75,8 @@ struct CommandContext {
     host_shared: PathBuf,
     /// User supplied command to run
     command: String,
+    /// virtio-serial output port name
+    command_output_port_name: String,
 }
 
 const QEMU_DEFAULT_ARGS: &[&str] = &["-nodefaults", "-display", "none"];
@@ -721,6 +723,7 @@ impl Qemu {
             should_cd: !self.image && self.rootfs == Target::default_rootfs(),
             host_shared: self.host_shared.clone(),
             command: self.command.clone(),
+            command_output_port_name: COMMAND_OUTPUT_PORT_NAME.into(),
         };
 
         // Same as above, ignore errors cuz only trivial bugs are possible


### PR DESCRIPTION
This fixes one of the major annoyances with vmtest: that long running
commands "hang" until they are completed. With this PR, output is live
streamed so that the user can be less anxious.

This PR is easier to review per-commit.

This closes #39.