### PR TITLE
Return RC code of command when running one-liner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,7 @@ fn main() -> Result<()> {
     let vmtest = config(&args)?;
     let filter = Regex::new(&args.filter).context("Failed to compile regex")?;
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&filter, show_cmd(&args));
-    let rc = i32::from(failed != 0);
+    let rc = ui.run(&filter, show_cmd(&args));
 
     exit(rc);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,6 +10,8 @@ use crate::output::Output;
 use crate::vmtest::Vmtest;
 
 const WINDOW_LENGTH: usize = 10;
+// sysexits.h catchall exit code for when we failed to run the vm for miscellaneous reasons.
+const EX_UNAVAILABLE: i32 = 69;
 
 /// Console UI
 ///
@@ -23,6 +25,13 @@ struct Stage {
     term: Term,
     lines: Vec<String>,
     expand: bool,
+}
+
+struct TargetUiRc {
+    // Return code of the command ran in the VM or None if it never ran.
+    rc: Option<i32>,
+    // Whether or not there was any error running the command, setting up the VM...
+    error: bool,
 }
 
 /// Helper to clear lines depending on whether or not a tty is attached
@@ -158,12 +167,16 @@ impl Ui {
 
     /// UI for a single target. Must be run on its own thread.
     ///
-    /// Returns if the target was successful or not>
-    fn target_ui(updates: Receiver<Output>, target: String, show_cmd: bool) -> bool {
+    /// Returns a TargetUiRc
+    fn target_ui(updates: Receiver<Output>, target: String, show_cmd: bool) -> TargetUiRc {
         let term = Term::stdout();
         let mut stage = Stage::new(term.clone(), &heading(&target, 1), None);
         let mut stages = 0;
         let mut errors = 0;
+        let mut rc = TargetUiRc {
+            rc: None,
+            error: false,
+        };
 
         // Main state machine loop
         loop {
@@ -208,6 +221,7 @@ impl Ui {
 
                     match r {
                         Ok(retval) => {
+                            rc.rc = Some(*retval as i32);
                             if *retval != 0 {
                                 error_out_stage(
                                     &mut stage,
@@ -236,7 +250,8 @@ impl Ui {
             term.write_line("FAILED").expect("Failed to write terminal");
         }
 
-        errors == 0
+        rc.error = errors != 0;
+        rc
     }
 
     /// Run all the targets in the provided `vmtest`
@@ -245,17 +260,21 @@ impl Ui {
     /// `show_cmd` specifies if the command output should always be shown.
     ///
     /// Note this function is "infallible" b/c on error it will display
-    /// the appropriate error message to screen. Rather, it returns how
-    /// many targets failed.
-    pub fn run(self, filter: &Regex, show_cmd: bool) -> usize {
+    /// the appropriate error message to screen.
+    /// In one-liner mode, it return the return code of the command, or EX_UNAVAILABLE if there
+    /// is an issue that prevents running the command.
+    /// When multiple targets are ran, it returns how many targets failed.
+    pub fn run(self, filter: &Regex, show_cmd: bool) -> i32 {
         let mut failed = 0;
-        for (idx, target) in self
+        let targets = self
             .vmtest
             .targets()
             .iter()
             .filter(|t| filter.is_match(&t.name))
-            .enumerate()
-        {
+            .collect::<Vec<_>>();
+        let single_cmd = targets.len() == 1;
+
+        for (idx, target) in targets.iter().enumerate() {
             let (sender, receiver) = channel::<Output>();
 
             // Start UI on its own thread b/c `Vmtest::run_one()` will block
@@ -265,9 +284,21 @@ impl Ui {
             // Run a target
             self.vmtest.run_one(idx, sender);
 
-            let success = ui.join().unwrap();
-            if !success {
-                failed += 1;
+            let rc = ui.join().unwrap();
+
+            if !single_cmd {
+                if rc.error {
+                    failed += 1;
+                }
+            } else {
+                match rc.rc {
+                    Some(rc) => {
+                        failed = rc;
+                    }
+                    None => {
+                        failed = EX_UNAVAILABLE;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
If we don't even get to run the command because of some other issues, EX_UNAVAILABLE (which is kind of the catchall for "something happened") is returned instead.

When multiple targets are ran, we can't really know what to return.... in which case the old behaviour is kept, e.g return the number of failed runs.

Added test to validate the behaviour.

Fixes #43