### PR TITLE
run qemu for a foreign architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ $ vmtest -k ./bzImage-v6.2 "uname -r"
 6.2.0
 ```
 
+To run an arbitrary command in a guest VM with a different kernel and rootfs:
+```
+$ vmtest -k ./bzImage-v6.2 -r ./rootfs "uname -r"
+=> bzImage-v6.2
+===> Booting
+===> Setting up VM
+===> Running command
+6.2.0
+```
+
+To run an arbitrary command from a kernel from another architecture in a guest VM:
+```
+$ vmtest -k ./kernels/Image-arm64 -r ./rootfs/ubuntu-lunar-arm64 -a aarch64 "uname -r"
+=> Image-arm64
+===> Booting
+===> Setting up VM
+===> Running command
+6.6.0-rc5-ga4a0c99f10ca-dirty
+```
+
 See `vmtest --help` for all options and flags.
 
 ### Config file interface
@@ -102,6 +122,13 @@ command = "uname -r | grep -e aws$"
 name = "OCI image"
 image = "./oci-stage-6/oci-stage-6-disk001.qcow2"
 command = "ls -l /mnt/vmtest && cat /proc/thiswillfail"
+
+[[target]]
+name = "Foreign Architecture"
+kernel = "./kernels/Image-arm64"
+arch = "aarch64"
+rootfs = "./rootfs/ubuntu-lunar-arm64"
+command = "uname -m | grep aarch64"
 ```
 
 In the above config, two see two defined targets: "AWS kernel" and "OCI image".
@@ -134,6 +161,11 @@ drwxr-xr-x 1 ubuntu ubuntu        200 Nov 14 20:41 avx-gateway-oci-stage-6
 cat: /proc/thiswillfail: No such file or directory
 Command failed with exit code: 1
 FAILED
+=> Foreign Architecture
+===> Booting
+===> Setting up VM
+===> Running command
+aarch64
 ```
 
 For full configuration documentation, see [config.md](./docs/config.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,6 +39,9 @@ The following fields are supported:
     * Path to rootfs to test against
     * If a relative path is provided, it will be interpreted as relative to
       `vmtest.toml`
+* `arch` (string)
+    * Default: the architecture vmtest was built for.
+    * Under which machine architecture to run the kernel.
 * `command` (string)
     * Required field
     * Command to run inside VM

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::env::consts::ARCH;
 use std::path::PathBuf;
 use std::vec::Vec;
 
@@ -106,6 +107,9 @@ pub struct Target {
     /// Default: /
     #[serde(default = "Target::default_rootfs")]
     pub rootfs: PathBuf,
+    /// Arch to run
+    #[serde(default = "Target::default_arch")]
+    pub arch: String,
     /// Command to run inside virtual machine.
     pub command: String,
 
@@ -119,6 +123,10 @@ impl Target {
     pub fn default_rootfs() -> PathBuf {
         "/".into()
     }
+    /// Default architecure to use if none are specified.
+    pub fn default_arch() -> String {
+        ARCH.to_string()
+    }
 }
 
 impl Default for Target {
@@ -130,6 +138,7 @@ impl Default for Target {
             kernel: None,
             kernel_args: None,
             rootfs: Self::default_rootfs(),
+            arch: Self::default_arch(),
             command: "".into(),
             vm: VMConfig::default(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::env::consts::ARCH;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::exit;
@@ -34,6 +35,9 @@ struct Args {
     /// Location of rootfs, default to host's /
     #[clap(short, long, conflicts_with = "config", default_value = Target::default_rootfs().into_os_string())]
     rootfs: PathBuf,
+    /// Arch to run
+    #[clap(short, long, default_value = ARCH, conflicts_with = "config")]
+    arch: String,
     #[clap(conflicts_with = "config")]
     command: Vec<String>,
 }
@@ -77,6 +81,7 @@ fn config(args: &Args) -> Result<Vmtest> {
                 uefi: false,
                 kernel: Some(kernel.clone()),
                 rootfs: args.rootfs.clone(),
+                arch: args.arch.clone(),
                 kernel_args: args.kargs.clone(),
                 command: args.command.join(" "),
                 vm: VMConfig::default(),


### PR DESCRIPTION
Now that we can run `vmtest` within a given chroot, we could host the chroot for a foreign architecture and run a vmtest in that chroot using a kernel matching that ar hitecture.

```
$ uname -a && cat /etc/lsb-release && RUST_LOG=debug cargo run -- -a aarch64 -k arm64/kbuild-output/arch/arm64/boot/Image.gz -r ../rootfs/ubuntu-lunar-arm64/ 'uname -a && cat /etc/lsb-release'
Linux surya 6.5.0-14-generic #14-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 14 14:59:49 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=23.10
DISTRIB_CODENAME=mantic
DISTRIB_DESCRIPTION="Ubuntu 23.10"
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/vmtest -a aarch64 -k arm64/kbuild-output/arch/arm64/boot/Image.gz -r ../rootfs/ubuntu-lunar-arm64/ 'uname -a && cat /etc/lsb-release'`
=> Image.gz
===> Booting
===> Setting up VM
===> Running command
Linux (none) 6.6.0-rc5-ga4a0c99f10ca-dirty #40 SMP Thu Oct 26 18:28:11 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=23.04
DISTRIB_CODENAME=lunar
DISTRIB_DESCRIPTION="Ubuntu 23.04"
```