### PR TITLE
[Target] implement Default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,21 @@ impl Target {
     }
 }
 
+impl Default for Target {
+    fn default() -> Self {
+        Self {
+            name: "".into(),
+            image: None,
+            uefi: false,
+            kernel: None,
+            kernel_args: None,
+            rootfs: Self::default_rootfs(),
+            command: "".into(),
+            vm: VMConfig::default(),
+        }
+    }
+}
+
 /// Config containing full test matrix
 #[derive(Deserialize)]
 pub struct Config {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -31,20 +31,14 @@ fn test_run() {
                 image: Some(asset("image-uefi.raw-efi")),
                 uefi: true,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
             Target {
                 name: "not uefi image boots without uefi flag".to_string(),
                 image: Some(asset("image-not-uefi.raw")),
                 uefi: false,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
         ],
     };
@@ -64,30 +58,21 @@ fn test_run_multiple_return_number_failures() {
                 image: Some(asset("image-uefi.raw-efi")),
                 uefi: true,
                 command: "exit 1".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
             Target {
                 name: "uefi image boots with uefi flag 2".to_string(),
                 image: Some(asset("image-uefi.raw-efi")),
                 uefi: true,
                 command: "exit 1".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
             Target {
                 name: "not uefi image boots without uefi flag".to_string(),
                 image: Some(asset("image-not-uefi.raw")),
                 uefi: false,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
         ],
     };
@@ -106,10 +91,7 @@ fn test_run_single_return_number_return_code() {
             image: Some(asset("image-not-uefi.raw")),
             uefi: false,
             command: "exit 12".to_string(),
-            kernel: None,
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
@@ -127,10 +109,7 @@ fn test_vmtest_infra_error() {
             image: Some(asset("not_an_actual_image")),
             uefi: false,
             command: "exit 12".to_string(),
-            kernel: None,
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
@@ -152,20 +131,14 @@ fn test_run_one() {
                 image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
             Target {
                 name: "not uefi image boots without uefi flag".to_string(),
                 image: Some(non_uefi_image.as_pathbuf()),
                 uefi: false,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
         ],
     };
@@ -190,20 +163,14 @@ fn test_run_out_of_bounds() {
                 image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
             Target {
                 name: "not uefi image boots without uefi flag".to_string(),
                 image: Some(non_uefi_image.as_pathbuf()),
                 uefi: false,
                 command: "/mnt/vmtest/main.sh nixos".to_string(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
-                vm: VMConfig::default(),
+                ..Default::default()
             },
         ],
     };
@@ -224,10 +191,7 @@ fn test_not_uefi() {
             image: Some(uefi_image.as_pathbuf()),
             uefi: false,
             command: "echo unreachable".to_string(),
-            kernel: None,
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
@@ -242,14 +206,10 @@ fn test_command_runs_in_shell() {
         target: vec![Target {
             name: "command is run in shell".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
             // `$0` is a portable way of getting the name of the shell without relying
             // on env vars which may be propagated from the host into the guest.
             command: "if true; then echo -n $0 > /mnt/vmtest/result; fi".to_string(),
-            image: None,
-            uefi: false,
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, dir) = setup(config, &[]);
@@ -271,12 +231,8 @@ fn test_kernel_target_env_var_propagation() {
         target: vec![Target {
             name: "host env vars are propagated into guest".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
             command: "echo -n $TEST_ENV_VAR > /mnt/vmtest/result".to_string(),
-            image: None,
-            uefi: false,
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
 
@@ -301,12 +257,8 @@ fn test_kernel_target_cwd_preserved() {
         target: vec![Target {
             name: "host cwd preserved in guest".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
             command: "cat text_file.txt".to_string(),
-            image: None,
-            uefi: false,
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
 
@@ -331,14 +283,10 @@ fn test_command_process_substitution() {
         target: vec![Target {
             name: "command can run process substitution".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
             // `$0` is a portable way of getting the name of the shell without relying
             // on env vars which may be propagated from the host into the guest.
             command: "cat <(echo -n $0) > /mnt/vmtest/result".to_string(),
-            image: None,
-            uefi: false,
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, dir) = setup(config, &[]);
@@ -358,12 +306,8 @@ fn test_qemu_error_shown() {
         target: vec![Target {
             name: "invalid kernel path".to_string(),
             kernel: Some(asset("doesn't exist")),
-            kernel_args: None,
-            rootfs: Target::default_rootfs(),
             command: "true".to_string(),
-            image: None,
-            uefi: false,
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, _dir) = setup(config, &[]);
@@ -387,11 +331,8 @@ fn test_kernel_ro_flag() {
             name: "cannot touch host rootfs with ro".to_string(),
             kernel: Some(asset("bzImage-v5.15-empty")),
             kernel_args: Some("ro".to_string()),
-            rootfs: Target::default_rootfs(),
             command: format!("touch {}/file", touch_dir.path().display()),
-            image: None,
-            uefi: false,
-            vm: VMConfig::default(),
+            ..Default::default()
         }],
     };
     let (vmtest, _dir) = setup(config, &[]);
@@ -412,13 +353,11 @@ fn test_run_custom_resources() {
                 image: Some(uefi_image_t1.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "[[ "$(nproc)" == "1" ]]""#.into(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     num_cpus: 1,
                     ..Default::default()
                 },
+                ..Default::default()
             },
             Target {
                 name: "Custom amount of RAM".to_string(),
@@ -427,13 +366,11 @@ fn test_run_custom_resources() {
                 // Should be in the 200 thousands, but it's variable.
                 command: r#"bash -xc "cat /proc/meminfo | grep 'MemTotal:         2..... kB'""#
                     .into(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     memory: "256M".into(),
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ],
     };
@@ -456,9 +393,6 @@ fn test_run_custom_mounts() {
                 image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "[[ -e /tmp/mount/README.md ]]""#.into(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     mounts: HashMap::from([(
                         "/tmp/mount".into(),
@@ -469,15 +403,13 @@ fn test_run_custom_mounts() {
                     )]),
                     ..Default::default()
                 },
+                ..Default::default()
             },
             Target {
                 name: "RO mount".to_string(),
                 image: Some(uefi_image.as_pathbuf()),
                 uefi: true,
                 command: r#"bash -xc "(touch /tmp/ro/hi && exit -1) || true""#.into(),
-                kernel: None,
-                kernel_args: None,
-                rootfs: Target::default_rootfs(),
                 vm: VMConfig {
                     mounts: HashMap::from([(
                         "/tmp/ro".into(),
@@ -488,6 +420,7 @@ fn test_run_custom_mounts() {
                     )]),
                     ..Default::default()
                 },
+                ..Default::default()
             },
         ],
     };


### PR DESCRIPTION
While some fields are clearly non-optional (name, command), having a default implementation makes target definition less cumbersome, mostly in tests.