### PR TITLE
fix targets filtering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,32 +71,41 @@ fn init_logging() -> Result<()> {
 }
 
 /// Configure a `Vmtest` instance from command line arguments.
+/// Filter out targets that don't match the provided regex.
+/// Filtering is only applied when a config file is provided.
 fn config(args: &Args) -> Result<Vmtest> {
-    if let Some(kernel) = &args.kernel {
-        let cwd = env::current_dir().context("Failed to get current directory")?;
-        let config = Config {
-            target: vec![Target {
-                name: kernel.file_name().unwrap().to_string_lossy().to_string(),
-                image: None,
-                uefi: false,
-                kernel: Some(kernel.clone()),
-                rootfs: args.rootfs.clone(),
-                arch: args.arch.clone(),
-                kernel_args: args.kargs.clone(),
-                command: args.command.join(" "),
-                vm: VMConfig::default(),
-            }],
-        };
-
-        Vmtest::new(cwd, config)
-    } else {
-        let default = Path::new("vmtest.toml").to_owned();
-        let config_path = args.config.as_ref().unwrap_or(&default);
-        let contents = fs::read_to_string(config_path).context("Failed to read config file")?;
-        let config = toml::from_str(&contents).context("Failed to parse config")?;
-        let base = config_path.parent().unwrap();
-
-        Vmtest::new(base, config)
+    match &args.kernel {
+        Some(kernel) => {
+            let cwd = env::current_dir().context("Failed to get current directory")?;
+            let config = Config {
+                target: vec![Target {
+                    name: kernel.file_name().unwrap().to_string_lossy().to_string(),
+                    image: None,
+                    uefi: false,
+                    kernel: Some(kernel.clone()),
+                    rootfs: args.rootfs.clone(),
+                    arch: args.arch.clone(),
+                    kernel_args: args.kargs.clone(),
+                    command: args.command.join(" "),
+                    vm: VMConfig::default(),
+                }],
+            };
+            Vmtest::new(cwd, config)
+        }
+        None => {
+            let default = Path::new("vmtest.toml").to_owned();
+            let config_path = args.config.as_ref().unwrap_or(&default);
+            let contents = fs::read_to_string(config_path).context("Failed to read config file")?;
+            let filter = Regex::new(&args.filter).context("Failed to compile regex")?;
+            let mut config: Config = toml::from_str(&contents).context("Failed to parse config")?;
+            config.target = config
+                .target
+                .into_iter()
+                .filter(|t| filter.is_match(&t.name))
+                .collect::<Vec<_>>();
+            let base = config_path.parent().unwrap();
+            Vmtest::new(base, config)
+        }
     }
 }
 
@@ -112,9 +121,92 @@ fn main() -> Result<()> {
 
     init_logging().context("Failed to initialize logging")?;
     let vmtest = config(&args)?;
-    let filter = Regex::new(&args.filter).context("Failed to compile regex")?;
     let ui = Ui::new(vmtest);
-    let rc = ui.run(&filter, show_cmd(&args));
+    let rc = ui.run(show_cmd(&args));
 
     exit(rc);
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use tempfile::{Builder, TempDir};
+
+    fn test_config() -> Result<TempDir> {
+        let tmp_dir = Builder::new().tempdir()?;
+        let config_path = tmp_dir.path().join("vmtest.toml");
+        fs::write(
+            &config_path,
+            r#"
+        [[target]]
+        name = "test1"
+        image = "test1.img"
+        command = "echo test1"
+        [[target]]
+        name = "test2"
+        kernel = "test2.kernel"
+        command = "echo test2"
+        "#,
+        )
+        .unwrap();
+        Ok(tmp_dir)
+    }
+
+    #[test]
+    fn test_config_no_filter() {
+        let tmp_dir = test_config().expect("Failed to create config");
+        let config_path = tmp_dir.path().join("vmtest.toml");
+
+        let args = Args::parse_from(&[
+            "cliname",
+            "-c",
+            config_path.to_str().expect("Failed to create config path"),
+        ]);
+        let vmtest = config(&args).expect("Failed to parse config");
+        assert_eq!(vmtest.targets().len(), 2);
+    }
+
+    #[test]
+    fn test_config_filter_match_all() {
+        let tmp_dir = test_config().expect("Failed to create config");
+        let config_path = tmp_dir.path().join("vmtest.toml");
+
+        let args = Args::parse_from(&[
+            "cliname",
+            "-c",
+            config_path.to_str().expect("Failed to create config path"),
+            "-f",
+            "test",
+        ]);
+        let vmtest = config(&args).expect("Failed to parse config");
+        assert_eq!(vmtest.targets().len(), 2);
+    }
+
+    #[test]
+    fn test_config_filter_match_last() {
+        let tmp_dir = test_config().expect("Failed to create config");
+        let config_path = tmp_dir.path().join("vmtest.toml");
+
+        let args = Args::parse_from(&[
+            "cliname",
+            "-c",
+            config_path.to_str().expect("Failed to create config path"),
+            "-f",
+            "test2",
+        ]);
+        let vmtest = config(&args).expect("Failed to parse config");
+        assert_eq!(vmtest.targets().len(), 1);
+        assert_eq!(vmtest.targets()[0].name, "test2");
+    }
+
+    // Test that when using the kernel argument, the filter is not applied.
+    #[test]
+    fn test_config_with_kernel_ignore_filter() {
+        let args =
+            Args::parse_from(&["cliname", "-k", "mykernel", "-f", "test2", "command to run"]);
+        let vmtest = config(&args).expect("Failed to parse config");
+        assert_eq!(vmtest.targets().len(), 1);
+        assert_eq!(vmtest.targets()[0].name, "mykernel");
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,6 @@ use std::thread;
 
 use anyhow::{anyhow, bail, Error, Result};
 use console::{strip_ansi_codes, style, truncate_str, Style, Term};
-use regex::Regex;
 
 use crate::output::Output;
 use crate::vmtest::Vmtest;
@@ -259,14 +258,9 @@ impl Ui {
     /// In one-liner mode, it return the return code of the command, or EX_UNAVAILABLE if there
     /// is an issue that prevents running the command.
     /// When multiple targets are ran, it returns how many targets failed.
-    pub fn run(self, filter: &Regex, show_cmd: bool) -> i32 {
+    pub fn run(self, show_cmd: bool) -> i32 {
         let mut failed = 0;
-        let targets = self
-            .vmtest
-            .targets()
-            .iter()
-            .filter(|t| filter.is_match(&t.name))
-            .collect::<Vec<_>>();
+        let targets = self.vmtest.targets();
         let single_cmd = targets.len() == 1;
 
         for (idx, target) in targets.iter().enumerate() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,8 +4,6 @@ use std::fs;
 use std::path::Path;
 use std::sync::mpsc::channel;
 
-use lazy_static::lazy_static;
-use regex::Regex;
 use tempfile::tempdir_in;
 use test_log::test;
 
@@ -16,10 +14,6 @@ use vmtest::{Config, Target, VMConfig};
 
 mod helpers;
 use helpers::*;
-
-lazy_static! {
-    static ref FILTER_ALL: Regex = Regex::new(".*").unwrap();
-}
 
 // Expect that we can run the entire matrix successfully
 #[test]
@@ -44,7 +38,7 @@ fn test_run() {
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&*FILTER_ALL, false);
+    let failed = ui.run(false);
     assert_eq!(failed, 0);
 }
 
@@ -78,7 +72,7 @@ fn test_run_multiple_return_number_failures() {
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&*FILTER_ALL, false);
+    let failed = ui.run(false);
     assert_eq!(failed, 2);
 }
 
@@ -96,7 +90,7 @@ fn test_run_single_return_number_return_code() {
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&*FILTER_ALL, false);
+    let failed = ui.run(false);
     assert_eq!(failed, 12);
 }
 
@@ -114,7 +108,7 @@ fn test_vmtest_infra_error() {
     };
     let (vmtest, _dir) = setup(config, &["main.sh"]);
     let ui = Ui::new(vmtest);
-    let failed = ui.run(&*FILTER_ALL, false);
+    let failed = ui.run(false);
     assert_eq!(failed, 69);
 }
 


### PR DESCRIPTION
`ui::run()` used to filter targets and call `vmtest::run_one()` using the index of the target in the resulting array.

The problem is that `self.vmtest` itself has the original list of targets, and therefore, the target index is different for `vmtest` and as seeing by `ui::run()`.

This change moved the logic of filtering targets into the config parsing logic. This way, both `ui` and `ui.vmtest` will have the same view of the targets and filtering does not need to be applied in multiple places.

Also add test to validate the behaviour.

To illustrate:

```
$ cat vmtest.toml
[[target]]
name = "test1"
kernel = "./kernels/bzImage-x86_64"
command = "echo test1"

[[target]]
name = "test2"
kernel = "./kernels/bzImage-x86_64"
command = "echo test2"

[[target]]
name = "test3"
kernel = "./kernels/bzImage-x86_64"
command = "echo test3"

$ vmtest -V
vmtest 0.8.2

$ vmtest -f test3
=> test3
===> Booting
===> Setting up VM
===> Running command
test1
```

and after the change:
```
$ cargo run -- -f test3
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/vmtest -f test3`
=> test3
===> Booting
===> Setting up VM
===> Running command
test3
```

Fixes: 77e0ccf91be0 ("Support --filter flag")