### PR TITLE
[release] Build vmtest binary for aarch64 and s390x too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,28 @@ jobs:
 
     - name: Build statically linked vmtest
       run: |
-        RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86_64-unknown-linux-gnu
-        cp ./target/x86_64-unknown-linux-gnu/release/vmtest ./vmtest-amd64
+        function gnu_to_debian() {
+          # Funtion to convert an architecture in Debian to its GNU equivalent,
+          # e.g amd64 -> x86_64
+          # CPUTABLE contains a list of debian_arch\tgnu_arch per line
+          # Compare of the first field matches and print the second one.
+          awk -v gnu_arch="$1" '$2 ~ gnu_arch {print $1}' /usr/share/dpkg/cputable
+        }
+
+        ARCHS=(x86_64 aarch64 s390x)
+
+        for arch in "${ARCHS[@]}"; do
+          # Install the required toolchain
+          sudo apt install -y gcc-${arch//_/-}-linux-gnu
+          rustup target add "${arch}-unknown-linux-gnu"
+          # Compile the binary
+          RUSTFLAGS="-C target-feature=+crt-static -C linker=/usr/bin/${arch}-linux-gnu-gcc" cargo build --release --target "${arch}-unknown-linux-gnu"
+          cp "./target/${arch}-unknown-linux-gnu/release/vmtest" "./vmtest-$(gnu_to_debian "${arch}")"
+        done
 
     - name: Create release
       uses: softprops/action-gh-release@v1
       with:
         name: Release ${{ github.ref_name }}
         generate_release_notes: true
-        files: ./vmtest-amd64
+        files: ./vmtest-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,24 +29,7 @@ jobs:
 
     - name: Build statically linked vmtest
       run: |
-        function gnu_to_debian() {
-          # Funtion to convert an architecture in Debian to its GNU equivalent,
-          # e.g amd64 -> x86_64
-          # CPUTABLE contains a list of debian_arch\tgnu_arch per line
-          # Compare of the first field matches and print the second one.
-          awk -v gnu_arch="$1" '$2 ~ gnu_arch {print $1}' /usr/share/dpkg/cputable
-        }
-
-        ARCHS=(x86_64 aarch64 s390x)
-
-        for arch in "${ARCHS[@]}"; do
-          # Install the required toolchain
-          sudo apt install -y gcc-${arch//_/-}-linux-gnu
-          rustup target add "${arch}-unknown-linux-gnu"
-          # Compile the binary
-          RUSTFLAGS="-C target-feature=+crt-static -C linker=/usr/bin/${arch}-linux-gnu-gcc" cargo build --release --target "${arch}-unknown-linux-gnu"
-          cp "./target/${arch}-unknown-linux-gnu/release/vmtest" "./vmtest-$(gnu_to_debian "${arch}")"
-        done
+        ./scripts/build_release.sh
 
     - name: Create release
       uses: softprops/action-gh-release@v1

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Build a release version of vmtest for a list of architectures.
+# The resulting binaries will be copied in the current directory and named vmtest-<arch>.
+#
+# This script assumes it is run on a Debian based system.
+#
+# Run this on your root host inside vmtest repository.
+#
+# Usage:
+#   ./scripts/build_release.sh
+#   ./scripts/build_release.sh x86_64 aarch64
+
+set -eu
+
+ARCHS=(x86_64 aarch64 s390x)
+
+if [[ $# -gt 0 ]]
+then
+    ARCHS=("$@")
+fi
+
+# Install the required toolchain for cross-compilation
+X_ARCHS=()
+for arch in "${ARCHS[@]}"; do
+    if [[ "${arch}" == "$(uname -m)" ]]; then
+        continue
+    fi
+    X_ARCHS+=("${arch}")
+done
+
+ARCHS_TO_EXPAND=$(IFS=, ; echo "${X_ARCHS[*]}")
+eval sudo apt install -y "gcc-{${ARCHS_TO_EXPAND//_/-}}-linux-gnu"
+eval rustup target add "{${ARCHS_TO_EXPAND}}-unknown-linux-gnu"
+
+for arch in "${ARCHS[@]}"; do
+    # Compile the binary
+    RUSTFLAGS="-C target-feature=+crt-static -C linker=/usr/bin/${arch}-linux-gnu-gcc" cargo build --release --target "${arch}-unknown-linux-gnu"
+    cp "./target/${arch}-unknown-linux-gnu/release/vmtest" "./vmtest-${arch}"
+done


### PR DESCRIPTION
Build vmtest for x86_64, aarch64, and s390x.
As a side effect, x86_64 does not need a x86_64 anymore to be compiled.

Example release: https://github.com/chantra/danobi-vmtest/releases/tag/v1.0.0