### PR TITLE
[debug] wrap qemu command arguments in quotes

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -645,7 +645,10 @@ impl Qemu {
         c.args(vmconfig_args(&target.vm));
 
         if log_enabled!(Level::Error) {
-            let args = c.get_args().map(|a| a.to_string_lossy()).join(" ");
+            let args = c
+                .get_args()
+                .map(|a| format!("\"{}\"", a.to_string_lossy()))
+                .join(" ");
             debug!(
                 "qemu invocation: {} {}",
                 c.get_program().to_string_lossy(),


### PR DESCRIPTION
The command that was printed by vmtest was not wrapping arguments in quotes. When trying to copy/paste the command, one had to find whatever was related to `-append` and wrap add quotes.

This wraps all argument in quotes so the printed command can be simply copy/pasted.

Before:
```
[16:34:03] chantra@surya:danobi-vmtest git:(master) $ RUST_LOG=debug cargo run -- -k kernels/bzImage-x86_64 "ls" 2>&1 | cat | grep invocation
[2024-01-18T00:34:10Z DEBUG vmtest::qemu] qemu invocation: qemu-system-x86_64 -nodefaults -display none -serial stdio -enable-kvm -cpu host -qmp unix:/tmp/qmp-264786.sock,server=on,wait=off -chardev socket,path=/tmp/qga-332867.sock,server=on,wait=off,id=qga0 -device virtio-serial -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 --device virtio-serial -chardev socket,path=/tmp/cmdout-123076.sock,server=on,wait=off,id=cmdout --device virtserialport,chardev=cmdout,name=org.qemu.virtio_serial.0 -virtfs local,id=root,path=/,mount_tag=/dev/root,security_model=none,multidevs=remap -kernel /home/chantra/devel/danobi-vmtest/kernels/bzImage-x86_64 -no-reboot -append rootfstype=9p rootflags=trans=virtio,cache=loose,msize=1048576 rw earlyprintk=serial,0,115200 printk.devkmsg=on console=0,115200 loglevel=7 raid=noautodetect init=/tmp/vmtest-initddkPv.sh panic=-1 -virtfs local,id=shared,path=/home/chantra/devel/danobi-vmtest,mount_tag=vmtest-shared,security_model=none,multidevs=remap -smp 2 -m 4G
```
After:
```
[16:34:33] chantra@surya:danobi-vmtest git:(command_quotes) $ RUST_LOG=debug cargo run -- -k kernels/bzImage-x86_64 "ls" 2>&1 | cat | grep invocation
[2024-01-18T00:34:40Z DEBUG vmtest::qemu] qemu invocation: qemu-system-x86_64 "-nodefaults" "-display" "none" "-serial" "stdio" "-enable-kvm" "-cpu" "host" "-qmp" "unix:/tmp/qmp-701433.sock,server=on,wait=off" "-chardev" "socket,path=/tmp/qga-669270.sock,server=on,wait=off,id=qga0" "-device" "virtio-serial" "-device" "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0" "--device" "virtio-serial" "-chardev" "socket,path=/tmp/cmdout-609567.sock,server=on,wait=off,id=cmdout" "--device" "virtserialport,chardev=cmdout,name=org.qemu.virtio_serial.0" "-virtfs" "local,id=root,path=/,mount_tag=/dev/root,security_model=none,multidevs=remap" "-kernel" "/home/chantra/devel/danobi-vmtest/kernels/bzImage-x86_64" "-no-reboot" "-append" "rootfstype=9p rootflags=trans=virtio,cache=loose,msize=1048576 rw earlyprintk=serial,0,115200 printk.devkmsg=on console=0,115200 loglevel=7 raid=noautodetect init=/tmp/vmtest-initXClKT.sh panic=-1" "-virtfs" "local,id=shared,path=/home/chantra/devel/danobi-vmtest,mount_tag=vmtest-shared,security_model=none,multidevs=remap" "-smp" "2" "-m" "4G"
```