### PR TITLE
Drop in Interactive shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +388,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +587,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
+name = "rexpect"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ff60778f96fb5a48adbe421d21bf6578ed58c0872d712e7e08593c195adff8"
+dependencies = [
+ "comma",
+ "nix",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "rstest"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +759,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +829,7 @@ dependencies = [
  "qapi",
  "rand",
  "regex",
+ "rexpect",
  "rstest",
  "scopeguard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,6 @@ tinytemplate = "1.2.1"
 toml = "0.5.9"
 
 [dev-dependencies]
-test-log = "0.2.11"
+rexpect = "0.5"
 rstest = "0.18.2"
+test-log = "0.2.11"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ $ vmtest -k ./kernels/Image-arm64 -r ./rootfs/ubuntu-lunar-arm64 -a aarch64 "una
 6.6.0-rc5-ga4a0c99f10ca-dirty
 ```
 
+It is also possible to get an interactive shell prompt in the guest by using the command `-`:
+```
+vmtest -k ./bzImage-v6.2 "-"
+...
+...
+root@(none):/#
+```
+
 See `vmtest --help` for all options and flags.
 
 ### Config file interface

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -31,7 +31,7 @@ log() {
 # procfs at guest /proc.
 /bin/mount -t proc -o nosuid,nodev,noexec proc /proc
 
-# So the kernel doesn't panic when if we exit
+# So the kernel doesn't panic when we exit
 trap 'poweroff -f' EXIT
 
 umask 022
@@ -101,5 +101,11 @@ if [[ -e /dev/kmsg ]]; then
     qga_logs="--logfile /dev/kmsg"
 fi
 
-log "Spawning qemu-ga"
-qemu-ga --method=virtio-serial --path="$vport" $qga_logs
+log "Spawning qemu-ga in the background"
+qemu-ga --method=virtio-serial --path="$vport" $qga_logs -d
+
+
+# Run a login shell
+# In non-interactive mode, init will block on the shell process. The VM will be killed through QMP.
+# In interactive mode, the user will be given a prompt, exiting the shell will trigger the trap function.
+/bin/bash --login

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ struct Args {
     /// Arch to run
     #[clap(short, long, default_value = ARCH, conflicts_with = "config")]
     arch: String,
+    /// Command to run in kernel mode. `-` to get an interactive shell.
     #[clap(conflicts_with = "config")]
     command: Vec<String>,
 }


### PR DESCRIPTION
When the magic command `-` is passed, and we are running in kernel mode, get a
shell prompt in the VM.

To do this, we can re-use the existing `run` framework with some changes:
- standard streams to the qemu command are not changed and instead are inherited
- child std is not streamed to the UI anymore.
- the command is not sent over qga anymore, we just wait for the qemu command to
  return (e.g when user exit its bash prompt) and exit

Fixes #54

Tested by running
```
RUST_LOG=debug cargo run -- -k kernels/bzImage-x86_64 -
```
and confirming no existing tests are broken.

Also could get it to work cross-platform:
```
cargo run --  -k ./kernels/Image-arm64 -r ./rootfs/ubuntu-lunar-arm64 -a aarch64 -
```