### PR TITLE
qemu: mount rootfs as read-only

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -643,7 +643,7 @@ impl Qemu {
                 target.rootfs.as_path(),
                 "root",
                 ROOTFS_9P_FS_MOUNT_TAG,
-                false,
+                true,
             ));
             c.args(kernel_args(
                 &kernel,


### PR DESCRIPTION
The contract is that the rootfs is mounted read-only. This was not happening.
When running the tool as an unprivileged user, this essentially was a no-op, but when running it using a rootfs owned by the user, it was then possible to write to those directories:

```
ls /tmp/main-s390x-chantra/home; \
> vmtest  -k s390x/kbuild-output/arch/s390/boot/bzImage -a s390x -r /tmp/main-s390x-chantra "touch /home/a"; \
> cargo run -- -k s390x/kbuild-output/arch/s390/boot/bzImage -a s390x -r /tmp/main-s390x-chantra "touch /home/b"; \
> ls /tmp/main-s390x-chantra/home
=> bzImage
===> Booting
===> Setting up VM
===> Running command

    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/vmtest -k s390x/kbuild-output/arch/s390/boot/bzImage -a s390x -r /tmp/main-s390x-chantra 'touch /home/b'`
=> bzImage
===> Booting
===> Setting up VM
===> Running command
touch: cannot touch '/home/b': Read-only file system
Command failed with exit code: 1

a
```