### PR TITLE
Set 9pfs mount cache option to mmap

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -37,7 +37,7 @@ const SHARED_9P_FS_MOUNT_TAG: &str = "vmtest-shared";
 const COMMAND_OUTPUT_PORT_NAME: &str = "org.qemu.virtio_serial.0";
 
 const SHARED_9P_FS_MOUNT_PATH: &str = "/mnt/vmtest";
-const MOUNT_OPTS_9P_FS: &str = "trans=virtio,cache=loose,msize=1048576";
+const MOUNT_OPTS_9P_FS: &str = "trans=virtio,cache=mmap,msize=1048576";
 const OVMF_PATHS: &[&str] = &[
     // Fedora
     "/usr/share/edk2/ovmf/OVMF_CODE.fd",


### PR DESCRIPTION
cache=loose or cache=fscache currently do not validate via host, which means that a file modified on the host does not mirror back in the guest without doing some deletion dance....

https://lore.kernel.org/lkml/CAFkjPTmVbyuA0jEAjYhsOsg-SE99yXgehmjqUZb4_uWS_L-ZTQ@mail.gmail.com/ 

mmap mode seems to be needed for `mmap` to actually work per https://wiki.qemu.org/Documentation/9p_root_fs#Boot_the_9p_Root_FS_System

Fixes #61