### PR TITLE
Improve interactive shell

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -108,4 +108,6 @@ qemu-ga --method=virtio-serial --path="$vport" $qga_logs -d
 # Run a login shell
 # In non-interactive mode, init will block on the shell process. The VM will be killed through QMP.
 # In interactive mode, the user will be given a prompt, exiting the shell will trigger the trap function.
-/bin/bash --login
+# We use `setsid` to make stdin a controlling tty and create a new session.
+# https://stackoverflow.com/a/77840840
+setsid --ctty --wait /bin/bash --login

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -627,7 +627,7 @@ impl Qemu {
 
         c.args(QEMU_DEFAULT_ARGS)
             .arg("-serial")
-            .arg("stdio")
+            .arg("mon:stdio")
             .args(kvm_args(&target.arch))
             .args(machine_args(&target.arch))
             .args(machine_protocol_args(&qmp_sock))


### PR DESCRIPTION
Make it possible to use job control in interactive shell.

Before this change, when dropped in an interactive shell, Ctrl-C would kill the whole qemu process.

to make this work, we need 2 things:
1) tell qemu to forward ctrl-c to the guest, this is done by using `-serial mon:stdio` instead of `-serial stdio`.
2) run bash in a controlling terminal so it can set job control.