### PR TITLE
Replace usage of console::user_attended()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use std::env;
 use std::env::consts::ARCH;
 use std::fs;
+use std::io::{stdout, IsTerminal as _};
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use console::user_attended;
 use env_logger::{fmt::Target as LogTarget, Builder};
 use regex::Regex;
 
@@ -50,7 +50,7 @@ struct Args {
 /// the console manipulations from the UI. If not a terminal, simply print
 /// to terminal and the logs will be inlined correctly.
 fn init_logging() -> Result<()> {
-    let target = match user_attended() {
+    let target = match stdout().is_terminal() {
         false => LogTarget::Stderr,
         true => {
             let file = fs::OpenOptions::new()


### PR DESCRIPTION
As of Rust 1.70 (already the program's stated minimum supported Rust version), the standard library supports checking whether an input/output stream is attached to a terminal. That seems to be exactly what console::user_attended() does (in a rather non-descript way, if you ask me).
Switch to using functionality directly provided by the standard library to minimize unnecessary dependencies and make the code clearer.