### PR TITLE
init: Do not mount over host /tmp in guest

### DIFF
--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -53,9 +53,6 @@ if [[ ! -d /dev/shm ]]; then
     mount -t tmpfs -o nosuid,nodev tmpfs /dev/shm
 fi
 
-log "Mounting tmpfs at /tmp"
-mount -t tmpfs -o nosuid,nodev tmpfs /tmp
-
 log "Mounting tmpfs at /run"
 mount -t tmpfs -o nosuid,nodev tmpfs /run
 ln -s /var/run ../run


### PR DESCRIPTION
Previously we mounted a new tmpfs inside the guest at /tmp, hiding the host /tmp. Originally this was to provide a measure of separation between host and guest, as guest likely needs a writable /tmp and by default rootfs was read-only.

Over time we moved towards less of a strict separation. These days, vmtest kernel targets exist to run the existing userspace on a different kernel. To that end, we should inherit the host /tmp.

Note we keep the mount over /run, as /run usually requires root to write. Since vmtest is run as normal user, the guest naturally cannot write to host /run. Notably qemu-guest-agent tries to create /var/run/qemu-ga.pid. So keep existing logic in place.

This closes #76.