### PR TITLE
init: Use host $PATH in init.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,6 @@ dependencies = [
  "console",
  "env_logger",
  "itertools",
- "lazy_static",
  "log",
  "qapi",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap = { version = "4.0.26", features = ["derive", "string"] }
 console = "0.15.5"
 env_logger = "0.10.0"
 itertools = "0.10.5"
-lazy_static = "1.4.0"
 log = "0.4.17"
 qapi = { version = "0.14.0", features = ["qmp", "qga"] }
 rand = "0.8.5"

--- a/src/init/init.sh.template
+++ b/src/init/init.sh.template
@@ -15,9 +15,9 @@
 
 set -eu
 
-export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+export PATH={ path }
 
-log() {
+log() \{
     if [[ -e /dev/kmsg ]]; then
 	echo "<6>vmtest: $*" >/dev/kmsg
     else
@@ -83,14 +83,14 @@ vport=
 for dir in /sys/class/virtio-ports/*; do
     if [[ "$(cat "$dir/name")" == "org.qemu.guest_agent.0" ]]; then
         vport_name=$(basename "$dir")
-        vport="/dev/${vport_name}"
+        vport="/dev/$\{vport_name}"
     fi
 done
 if [[ -z "$vport" ]]; then
     log "Failed to locate qemu-guest-agent virtio-port"
     exit 1
 fi
-log "Located qemu-guest-agent virtio port: ${vport}"
+log "Located qemu-guest-agent virtio port: $\{vport}"
 
 # Send QGA logs out via kmsg if possible
 qga_logs=


### PR DESCRIPTION
Currently all kernel target commands use host environment variables. However, init.sh uses a hard coded $PATH. This gap is most noticible on nix/nixos systems b/c nothing exists in the hard coded path. So kernel target guests are unable to find qemu-ga.

Plug this gap by templatizing init.sh and filling in with host $PATH.

Note init.sh.template now needs to be careful about escaping `{`, as that's reserved by TinyTemplate now.

This closes #79.