### PR TITLE
Simplify gen_sock() helper

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -120,14 +120,9 @@ fn host_supports_kvm(arch: &str) -> bool {
 
 // Generate a path to a randomly named socket
 fn gen_sock(prefix: &str) -> PathBuf {
-    let mut path = PathBuf::new();
-    path.push("/tmp");
-
     let id = rand::thread_rng().gen_range(100_000..1_000_000);
     let sock = format!("/tmp/{prefix}-{id}.sock");
-    path.push(sock);
-
-    path
+    PathBuf::from(sock)
 }
 
 // Given a guest temp dir and a host init path, generate the path to the init file


### PR DESCRIPTION
PathBuf::push(), when provided with an absolute path, will just replace the "self" path with said absolute path. This is precisely what is happening inside gen_sock(), although not intentionally. There is no need to push anything: we already formatted the full absolute path. Just convert the string into a path.