### PR TITLE
build_kernel: Speed up docker image creation

### DIFF
--- a/scripts/docker/Dockerfile.kernel
+++ b/scripts/docker/Dockerfile.kernel
@@ -1,10 +1,6 @@
 ARG ALPINE_VERSION
 FROM alpine:${ALPINE_VERSION}
 
-ARG KERNEL_REPO=https://github.com/torvalds/linux.git
-ARG KERNEL_TAG
-ARG DISTRO
-
 RUN apk update && apk add \
   bash \
   bison \
@@ -25,6 +21,10 @@ RUN apk update && apk add \
   zstd
 
 WORKDIR /
+
+ARG KERNEL_REPO=https://github.com/torvalds/linux.git
+ARG KERNEL_TAG
+ARG DISTRO
 
 RUN git clone --depth 1 ${KERNEL_REPO} linux --branch ${KERNEL_TAG}
 WORKDIR linux


### PR DESCRIPTION
When building multiple kernels on the same machine, docker has to rebuild the layers over and over because the values of KERNEL_TAG/DISTRO have changed (and would be the same of KERNEL_REPO was modified).

By moving them *after* the package installation, it does speed up the turnover.