### PR TITLE
Use single dash -device option

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -428,7 +428,7 @@ fn kernel_args(
 fn virtio_serial_args(host_sock: &Path) -> Vec<OsString> {
     let mut args: Vec<OsString> = Vec::new();
 
-    args.push("--device".into());
+    args.push("-device".into());
     args.push("virtio-serial".into());
 
     args.push("-chardev".into());
@@ -438,7 +438,7 @@ fn virtio_serial_args(host_sock: &Path) -> Vec<OsString> {
     arg.push(",server=on,wait=off,id=cmdout");
     args.push(arg);
 
-    args.push("--device".into());
+    args.push("-device".into());
     arg = OsString::new();
     arg.push("virtserialport,chardev=cmdout,name=");
     arg.push(COMMAND_OUTPUT_PORT_NAME);


### PR DESCRIPTION
It seems odd to use `--device` in some places and `-device` in others. It's also not in line with our usage of other Qemu options, which all use a single dash (for better or worse).
Change `--device` to `-device` for consistency.