### PR TITLE
Remove a bunch more clones

### DIFF
--- a/src/vmtest.rs
+++ b/src/vmtest.rs
@@ -120,7 +120,7 @@ impl Vmtest {
         target.rootfs = self.resolve_path(target.rootfs.as_path());
         target.vm.bios = target.vm.bios.map(|s| self.resolve_path(s.as_path()));
 
-        Qemu::new(updates, &target, &self.base).context("Failed to setup QEMU")
+        Qemu::new(updates, target, &self.base).context("Failed to setup QEMU")
     }
 
     /// Run a single target


### PR DESCRIPTION
We the Qemu::new() constructor might as well just consume the Target object, given that it won't be used afterwards. Adjust the signature and then just pull out the members we need instead of cloning them, removing a bunch of unnecessary allocations.
Similarly, the CommandContext that we instantiate just for the sake of conveying some data to the template does not need to contain any owned objects. So just work with references to existing ones, eliminating a bunch of more clones.