### PR TITLE
Add support for riscv64

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -262,6 +262,9 @@ fn kvm_args(arch: &str) -> Vec<&'static str> {
             "aarch64" | "s390x" => {
                 args.push("max");
             }
+            "riscv64" => {
+                args.push("rv64,sscofpmf=true");
+            }
             _ => {
                 args.push("qemu64");
             }
@@ -272,15 +275,11 @@ fn kvm_args(arch: &str) -> Vec<&'static str> {
 
 /// Generate arguments for which qemu machine to use
 fn machine_args(arch: &str) -> Vec<&'static str> {
-    let mut args = Vec::new();
-
-    if arch == "aarch64" {
-        // aarch64 does not have default machines.
-        args.push("-machine");
-        args.push("virt,gic-version=3");
+    match arch {
+        "aarch64" => vec!["-machine", "virt,gic-version=3"],
+        "riscv64" => vec!["-machine", "virt"],
+        _ => vec![],
     }
-
-    args
 }
 
 /// Generate arguments for setting up QMP control socket on host


### PR DESCRIPTION
Re-using the options used in https://lore.kernel.org/all/20240905081401.1894789-10-pulehui@huaweicloud.com/ add support for running vmtest against a riscv64 target.

Tested by running:
```
cargo run -- \
    -k /tmp/kbuild-riscv64/arch/riscv/boot/Image \
    -r ../libbpf-ci/libbpf-vmtest-rootfs-2024.09.09-noble-riscv64 \
    -a riscv64 \
    'uname -a'
```

Which generated https://gist.github.com/chantra/c595fa58ef6fdc72f567e21c1c207e15

/tmp/kbuild-riscv64/arch/riscv/boot/Image is a kernel cross-compiled using:
```
make ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- O=/tmp/kbuild-riscv64 -j4 all
```

libbpf-vmtest-rootfs-2024.09.09-noble-riscv64 is a rootgs generated by
```
make ARCHS=riscv64
```
using https://github.com/libbpf/ci/blob/main/rootfs/ into which I chrooted and installed `qemu-guest-agent`.