### PR TITLE
Added support for using a custom QEMU binary

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -110,6 +110,8 @@ pub struct Target {
     /// Arch to run
     #[serde(default = "Target::default_arch")]
     pub arch: String,
+    /// Command used to launch QEMU
+    pub qemu_command: Option<String>,
     /// Command to run inside virtual machine.
     pub command: String,
 
@@ -139,6 +141,7 @@ impl Default for Target {
             kernel_args: None,
             rootfs: Self::default_rootfs(),
             arch: Self::default_arch(),
+            qemu_command: None,
             command: "".into(),
             vm: VMConfig::default(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,11 @@ struct Args {
     /// Arch to run
     #[clap(short, long, default_value = ARCH, conflicts_with = "config")]
     arch: String,
+    /// Command to use to launch QEMU. Can be a full path or a PATH-resolved binary. If none is
+    /// provided, we default to `qemu-system-$ARCH`, where $ARCH is the value of the `arch`
+    /// argument
+    #[clap(short, long, conflicts_with = "config")]
+    qemu_command: Option<String>,
     /// Command to run in kernel mode. `-` to get an interactive shell.
     #[clap(conflicts_with = "config")]
     command: Vec<String>,
@@ -113,6 +118,7 @@ fn config(args: &Args) -> Result<Vmtest> {
                     rootfs: args.rootfs.clone(),
                     arch: args.arch.clone(),
                     kernel_args: args.kargs.clone(),
+                    qemu_command: args.qemu_command.clone(),
                     command: args.command.join(" "),
                     vm: VMConfig::default(),
                 }],


### PR DESCRIPTION
I've been looking into getting `vmtest` to work on a RHEL 8 system. After some digging me and @javierhonduco did, we found that one of the issues is that RHEL's QEMU installation is substantially different from most other Linux distros, as it does not create `qemu-system-*` binaries, but instead has a binary in `/usr/libexec/qemu-kvm`. In order to further test, overriding the binary path used to find QEMU would be extremely helpful. This PR does that.

# Manual Testing
Ran this on a RHEL machine:
```
$ cargo run -- -k ~/code/lightswitch-kernels/bzImage_v6.9-rc5 "uname -r"
[...]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.99s
     Running `target/debug/vmtest -k /home/cloud-user/code/lightswitch-kernels/bzImage_v6.9-rc5 'uname -r'`
=> bzImage_v6.9-rc5
Failed to setup QEMU

Caused by:
    0: Did not find QEMU binary qemu-system-x86_64. Make sure QEMU is installed
    1: No such file or directory (os error 2)

$ cargo run -- -k ~/code/lightswitch-kernels/bzImage_v6.9-rc5 -q /usr/libexec/qemu-kvm "uname -r"
[...]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/vmtest -k /home/cloud-user/code/lightswitch-kernels/bzImage_v6.9-rc5 -q /usr/libexec/qemu-kvm 'uname -r'`
=> bzImage_v6.9-rc5
===> Booting
qemu-kvm: -virtfs local,id=root,path=/,mount_tag=/dev/root,security_model=none,multidevs=remap: 'virtio-9p-pci' is not a valid device model name


Caused by:
    0: Failed to connect QMP
    1: Connection refused (os error 111)
```

The former failed to launch QEMU (with a clearer error message than before), the latter failed to start _after_ launching QEMU (RHEL 8 does not support 9p from what we were able to find).