### PR TITLE
Fix warnings and add CI lint checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,9 @@ jobs:
           sudo udevadm trigger --name-match=kvm
         fi
 
+    - name: Run clippy
+      run: make lint
+
     - name: Run integration tests
       run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ clean:
 	@cargo clean
 	@rm -rf $(ASSET_DIRECTORY)
 
+.PHONY: lint
+lint:
+	@cargo clippy -- -D warnings
+
 $(ASSET_DIRECTORY):
 	@mkdir -p $@
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,7 @@ pub struct Target {
     ///
     /// * The path is relative to `vmtest.toml`.
     /// * If not specified, the host's rootfs will be used.
+    ///
     /// Default: /
     #[serde(default = "Target::default_rootfs")]
     pub rootfs: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ mod tests {
         let tmp_dir = test_config().expect("Failed to create config");
         let config_path = tmp_dir.path().join("vmtest.toml");
 
-        let args = Args::parse_from(&[
+        let args = Args::parse_from([
             "cliname",
             "-c",
             config_path.to_str().expect("Failed to create config path"),
@@ -199,7 +199,7 @@ mod tests {
         let tmp_dir = test_config().expect("Failed to create config");
         let config_path = tmp_dir.path().join("vmtest.toml");
 
-        let args = Args::parse_from(&[
+        let args = Args::parse_from([
             "cliname",
             "-c",
             config_path.to_str().expect("Failed to create config path"),
@@ -215,7 +215,7 @@ mod tests {
         let tmp_dir = test_config().expect("Failed to create config");
         let config_path = tmp_dir.path().join("vmtest.toml");
 
-        let args = Args::parse_from(&[
+        let args = Args::parse_from([
             "cliname",
             "-c",
             config_path.to_str().expect("Failed to create config path"),
@@ -230,8 +230,7 @@ mod tests {
     // Test that when using the kernel argument, the filter is not applied.
     #[test]
     fn test_config_with_kernel_ignore_filter() {
-        let args =
-            Args::parse_from(&["cliname", "-k", "mykernel", "-f", "test2", "command to run"]);
+        let args = Args::parse_from(["cliname", "-k", "mykernel", "-f", "test2", "command to run"]);
         let vmtest = config(&args).expect("Failed to parse config");
         assert_eq!(vmtest.targets().len(), 1);
         assert_eq!(vmtest.targets()[0].name, "mykernel");

--- a/src/qga.rs
+++ b/src/qga.rs
@@ -30,6 +30,7 @@ pub struct QgaWrapper {
 pub struct Version {
     pub major: u8,
     pub minor: u8,
+    #[allow(unused)]
     pub patch: u8,
 }
 

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -16,8 +16,8 @@ use vmtest::Config;
 // Returns a path to a test asset
 pub fn asset(name: &str) -> PathBuf {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let asset = root.join("tests/.assets").join(name);
-    asset
+
+    root.join("tests/.assets").join(name)
 }
 
 // Set up a test run

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::path::Path;
 use std::sync::mpsc::channel;
 
-use rexpect;
 use tempfile::{tempdir, tempdir_in};
 use test_log::test;
 


### PR DESCRIPTION
Currently, there are warnings on main, and none of the CI checks verify warnings. This PR:
- Fixes the warning
- Fixes other clippy checks
- Adds a lint step to CI