### PR TITLE
Resolve mounts host_path relatively to vmtest.toml

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -86,6 +86,8 @@ The Mount struct for defining additional host mounts into the VM.
 * `host_path` (string)
     * Required field
     * Path on the host.
+    * If a relative path is provided, it will be interpreted as relative to
+      `vmtest.toml`
 * `writable` (bool)
     * Optional field
     * Whether this mount is writable in the VM.

--- a/src/vmtest.rs
+++ b/src/vmtest.rs
@@ -119,6 +119,9 @@ impl Vmtest {
         target.kernel = target.kernel.map(|s| self.resolve_path(s.as_path()));
         target.rootfs = self.resolve_path(target.rootfs.as_path());
         target.vm.bios = target.vm.bios.map(|s| self.resolve_path(s.as_path()));
+        target.vm.mounts.iter_mut().for_each(|(_, m)| {
+            m.host_path = self.resolve_path(m.host_path.as_path());
+        });
 
         Qemu::new(updates, target, &self.base).context("Failed to setup QEMU")
     }


### PR DESCRIPTION
When a non-default `rootfs` is used, and vmtest is run through `go test -exec`, the binary executed within the VM can't be found, because that rootfs doesn't contain the test binary compiled on the fly. So a custom mount has to be specified.

But, before that commit, if a relative `host_path` was used, it'd be passed as is to qemu, and thus would be resolved as relative to the cwd where qemu was running.

In the case of Go, if a directory was passed to `go test` (eg. `./integration/...`), and `GOTMPDIR=.` was set, Go would compile the test binary within its original cwd (eg. project root dir), and then launch vmtest in the 'directory under test' (eg. `./integration`), so the relative mount would resolve to the directory where vmtest was started (eg. `./integration`) -- a directory that doesn't contain the test binary.

To fix this mismatch, resolve `host_path` relative to the `vmtest.toml` file.

FWIW this doesn't fully solve the original issue, unless the VM path put in the config file is hardcoded to the cwd of `go test -exec`. To overcome this, one can prepend the inline command with a call to `mkdir` + `ln`:

```sh
GOTMPDIR=. go test -exec "vmtest -c $(pwd)/vmtest.toml -- mkdir $(realpath ..); ln -s /skbdump/ $(pwd); " ./integration/...
```