### PR TITLE
qga: Fail faster if guest panics

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -1063,7 +1063,7 @@ impl Qemu {
         debug!("QMP info: {:#?}", qmp_info);
 
         // Connect to QGA socket
-        let qga = QgaWrapper::new(&self.qga_sock, host_supports_kvm(&self.arch));
+        let qga = QgaWrapper::new(&self.qga_sock, host_supports_kvm(&self.arch), &mut child);
         let qga = match qga {
             Ok(q) => q,
             Err(e) => {


### PR DESCRIPTION
Before, if guest panics, QgaWrapper still waits up to 60s/120s to return a failure to the user. There's no need for that. Let's make it fail fast by circuit breaking if qemu has already exited.

This closes #99.