### PR TITLE
init: Set QEMU state dir/PID file path directly

### DIFF
--- a/src/init/init.sh.template
+++ b/src/init/init.sh.template
@@ -99,7 +99,11 @@ if [[ -e /dev/kmsg ]]; then
 fi
 
 log "Spawning qemu-ga in the background"
-qemu-ga --method=virtio-serial --path="$vport" $qga_logs -d
+# These --statedir and --pidfile match th default on typical QEMU builds, but
+# versions exist where the default is something else. See
+# https://github.com/danobi/vmtest/issues/101
+qemu-ga --statedir /var/run --pidfile /var/run/qemu-ga.pid \
+    --method=virtio-serial --path="$vport" $qga_logs -d
 
 
 # Run a login shell


### PR DESCRIPTION
This fixes https://github.com/danobi/vmtest/issues/101 for me.

I'm not sure why I didn't used to hit this. I think the actual issue is that /var/local/run is owned by a privilged user and has no global write perms on my host system.

My confidence is not very high that I really understand this system so please review with skepticism :)