### PR TITLE
qga: Use 80s timeout even for KVM

### DIFF
--- a/src/qga.rs
+++ b/src/qga.rs
@@ -10,7 +10,7 @@ use log::{debug, error, info, warn};
 use qapi::{qga, Command as QapiCommand, Qga};
 use rand::Rng;
 
-const KVM_TIMEOUT: Duration = Duration::from_secs(60);
+const KVM_TIMEOUT: Duration = Duration::from_secs(80);
 const EMULATE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// This is a wrapper around [`Qga`] such that we can execute QGA commands


### PR DESCRIPTION
With all the debug options turned on in the kernel, it can take ~60s even on my relatively powerful machine (Ryzen 5950x). 80s ought to be enough for now.

Recently we landed a change to make the error quicker when the kernel panics, so this change in timeout shouldn't affect much.