### PR TITLE
[qemu] Add custom kvm cpu args support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,11 @@ pub struct Target {
     ///
     /// Arguments are only valid for kernel targets.
     pub kernel_args: Option<String>,
+    /// KVM -cpu arguments are only valid for KVM enabled targets.
+    ///
+    /// Default: host
+    #[serde(default = "Target::default_kvm_cpu_args")]
+    pub kvm_cpu_args: Option<String>,
     /// Path to rootfs to test against.
     ///
     /// * The path is relative to `vmtest.toml`.
@@ -130,6 +135,10 @@ impl Target {
     pub fn default_arch() -> String {
         ARCH.to_string()
     }
+    /// Default kvm cpu args to use if none are specified.
+    pub fn default_kvm_cpu_args() -> Option<String> {
+        Some("host".into())
+    }
 }
 
 impl Default for Target {
@@ -140,6 +149,7 @@ impl Default for Target {
             uefi: false,
             kernel: None,
             kernel_args: None,
+            kvm_cpu_args: None,
             rootfs: Self::default_rootfs(),
             arch: Self::default_arch(),
             qemu_command: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,9 @@ struct Args {
     /// Additional kernel command line arguments
     #[clap(long, conflicts_with = "config")]
     kargs: Option<String>,
+    /// KVM -cpu arguments
+    #[clap(long, conflicts_with = "config", default_value = "host")]
+    kvm_cpu_args: Option<String>,
     /// Location of rootfs, default to host's /
     #[clap(short, long, conflicts_with = "config", default_value = Target::default_rootfs().into_os_string())]
     rootfs: PathBuf,
@@ -122,6 +125,7 @@ fn config(args: &Args) -> Result<Vmtest> {
                     rootfs: args.rootfs.clone(),
                     arch: args.arch.clone(),
                     kernel_args: args.kargs.clone(),
+                    kvm_cpu_args: args.kvm_cpu_args.clone(),
                     qemu_command: args.qemu_command.clone(),
                     command: args.command.join(" "),
                     vm: VMConfig::default(),


### PR DESCRIPTION
When improve `bpf_get_branch_snapshot()` helper, it requires passing LBR into the VM like `-cpu,host,pmu=on,lbr-fmt=0x5`.

Then, in the VM, confirm the LBR is supported:

```bash
root@(none):/# dmesg | grep -i lbr
[    0.394406] Performance Events: Skylake events, 32-deep LBR, full-width counters, Intel PMU driver.
```

With this commit, the VM can be created by
`vmtest -k $(make -s image_name) --kvm-cpu-args 'host,pmu=on,lbr-fmt=0x5' -`.