### PR TITLE
init: ignore error mounting cgroups

### DIFF
--- a/src/init/init.sh.template
+++ b/src/init/init.sh.template
@@ -67,7 +67,7 @@ log "Mounting tracefs at /sys/kernel/debug/tracing"
 mount -t tracefs tracefs /sys/kernel/debug/tracing || log "Failed to mount tracefs. CONFIG_DEBUG_FS might be missing from the kernel config"
 
 log "Mounting cgroup2 at /sys/fs/cgroup"
-mount -t cgroup2 -o nosuid,nodev,noexec cgroup2 /sys/fs/cgroup
+mount -t cgroup2 -o nosuid,nodev,noexec cgroup2 /sys/fs/cgroup || log "Failed to mount cgroups. CONFIG_CGROUPS might be missing from the kernel config"
 
 log "Mounting tmpfs at /mnt"
 mount -t tmpfs -o nosuid,nodev tmpfs /mnt


### PR DESCRIPTION
Hello,

I just ran vmtest to check a bug that was reported with latest kernel and ran into this as my test kernel is pretty bare; I don't think we need cgroups anywhere so it's probably just as good to do the same as debugfs and ignore errors.

---------------------

In the spirit of #20 ignoring errors for debugfs, also ignore errors when the kernel is built without cgroups as we do not actually use the cgroups for anything in vmtest itself.

Leave a log suggesting to enable the config like we do with debugfs.