### PR TITLE
chore: Add 6.12 and 6.18 LTS kernels.

### DIFF
--- a/tests/KERNELS
+++ b/tests/KERNELS
@@ -17,3 +17,11 @@ v6.2 fedora38
 v6.6 default
 v6.6 archlinux
 v6.6 fedora38
+
+v6.12 default
+v6.12 archlinux
+v6.12 fedora38
+
+v6.18 default
+v6.18 archlinux
+v6.18 fedora38


### PR DESCRIPTION
2 new LTS kernels were released since #65 . Add them to the list.